### PR TITLE
Add safe drawing insets to screens

### DIFF
--- a/app/src/main/java/com/app/tibibalance/ui/screens/auth/forgot/ForgotPasswordScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/auth/forgot/ForgotPasswordScreen.kt
@@ -140,7 +140,11 @@ fun ForgotPasswordScreen(
     )
 
     // Contenedor principal que ocupa toda la pantalla.
-    Box(Modifier.fillMaxSize()) {
+    Box(
+        Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing)
+    ) {
 
         /* ---------- CONTENIDO PRINCIPAL ---------- */
         // Columna para organizar los elementos verticalmente, con scroll.

--- a/app/src/main/java/com/app/tibibalance/ui/screens/auth/signin/SignInScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/auth/signin/SignInScreen.kt
@@ -117,6 +117,7 @@ fun SignInScreen(
     Box(
         Modifier
             .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing)
             .background(gradient)
     ) {
         Column(

--- a/app/src/main/java/com/app/tibibalance/ui/screens/auth/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/auth/signup/SignUpScreen.kt
@@ -116,7 +116,10 @@ fun SignUpScreen(
     )
 
     Box(
-        Modifier.fillMaxSize().background(gradient)
+        Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing)
+            .background(gradient)
     ) {
         /* scrollable column */
         Column(

--- a/app/src/main/java/com/app/tibibalance/ui/screens/auth/verify/VerifyEmailScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/auth/verify/VerifyEmailScreen.kt
@@ -157,6 +157,7 @@ fun VerifyEmailScreen(
     Box(
         Modifier
             .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing)
             .background(gradient)
     ) {
 

--- a/app/src/main/java/com/app/tibibalance/ui/screens/changepassword/ChangePasswordScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/changepassword/ChangePasswordScreen.kt
@@ -60,7 +60,11 @@ fun ChangePasswordScreen(
         listOf(Color(0xFF3EA8FE).copy(alpha = .25f), Color.White)
     )
 
-    Box(Modifier.fillMaxSize()) {
+    Box(
+        Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing)
+    ) {
         Column(
             Modifier
                 .fillMaxSize()

--- a/app/src/main/java/com/app/tibibalance/ui/screens/emotional/EmotionalCalendarScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/emotional/EmotionalCalendarScreen.kt
@@ -55,6 +55,7 @@ fun EmotionalCalendarScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing)
             .background(
                 Brush.verticalGradient(
                     listOf(Color(0xFF3EA8FE).copy(.25f), Color.White)

--- a/app/src/main/java/com/app/tibibalance/ui/screens/habits/HabitsScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/habits/HabitsScreen.kt
@@ -5,6 +5,8 @@ import androidx.annotation.RequiresApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -45,7 +47,12 @@ fun HabitsScreen(
         }
     }
 
-    Box(Modifier.fillMaxSize().background(gradient)) {
+    Box(
+        Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing)
+            .background(gradient)
+    ) {
         when (val s = ui) {
             HabitsUiState.Loading -> Centered("Cargando…")
             is HabitsUiState.Error -> Centered(s.msg)

--- a/app/src/main/java/com/app/tibibalance/ui/screens/habits/addHabitWizard/AddHabitModal.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/habits/addHabitWizard/AddHabitModal.kt
@@ -54,7 +54,11 @@ fun AddHabitModal(
         val pager = rememberPagerState(ui.currentStep) { 4 }
         LaunchedEffect(ui.currentStep) { pager.animateScrollToPage(ui.currentStep) }
 
-        Column(Modifier.fillMaxSize()) {
+        Column(
+            Modifier
+                .fillMaxSize()
+                .windowInsetsPadding(WindowInsets.safeDrawing)
+        ) {
 
             HorizontalPager(
                 state             = pager,

--- a/app/src/main/java/com/app/tibibalance/ui/screens/habits/addHabitWizard/step/BasicInfoStep.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/habits/addHabitWizard/step/BasicInfoStep.kt
@@ -42,6 +42,7 @@ fun BasicInfoStep(
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing)
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 12.dp, vertical = 16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)

--- a/app/src/main/java/com/app/tibibalance/ui/screens/habits/addHabitWizard/step/NotificationStep.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/habits/addHabitWizard/step/NotificationStep.kt
@@ -51,6 +51,7 @@ fun NotificationStep(
     Column(
         Modifier
             .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing)
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 12.dp, vertical = 16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)

--- a/app/src/main/java/com/app/tibibalance/ui/screens/habits/addHabitWizard/step/SuggestionStep.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/habits/addHabitWizard/step/SuggestionStep.kt
@@ -36,6 +36,7 @@ fun SuggestionStep(
     Column(
         Modifier
             .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing)
             .padding(12.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {

--- a/app/src/main/java/com/app/tibibalance/ui/screens/habits/addHabitWizard/step/TrackingStep.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/habits/addHabitWizard/step/TrackingStep.kt
@@ -72,6 +72,7 @@ fun TrackingStep(
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing)
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 12.dp, vertical = 16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)

--- a/app/src/main/java/com/app/tibibalance/ui/screens/habits/editHabitWizard/EditHabitModal.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/habits/editHabitWizard/EditHabitModal.kt
@@ -73,7 +73,11 @@ fun EditHabitModal(
             } else pager.animateScrollToPage(ui.currentStep)
         }
 
-        Column(Modifier.fillMaxSize()) {
+        Column(
+            Modifier
+                .fillMaxSize()
+                .windowInsetsPadding(WindowInsets.safeDrawing)
+        ) {
 
             /* ---------- páginas ---------- */
             HorizontalPager(

--- a/app/src/main/java/com/app/tibibalance/ui/screens/launch/LaunchScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/launch/LaunchScreen.kt
@@ -90,6 +90,7 @@ fun LaunchScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing)
             .background(bg)
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 24.dp, vertical = 32.dp),

--- a/app/src/main/java/com/app/tibibalance/ui/screens/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/onboarding/OnboardingScreen.kt
@@ -62,6 +62,7 @@ fun OnboardingScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing)
             .background(gradient),
         contentAlignment = Alignment.Center // Centra el contenido de este Box (la Column principal)
     ) {

--- a/app/src/main/java/com/app/tibibalance/ui/screens/profile/EditProfileScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/profile/EditProfileScreen.kt
@@ -18,6 +18,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -127,6 +129,7 @@ fun EditProfileScreen(
         Column(
             Modifier
                 .fillMaxSize()
+                .windowInsetsPadding(WindowInsets.safeDrawing)
                 .background(gradient)
                 .verticalScroll(rememberScrollState())
                 .padding(24.dp),

--- a/app/src/main/java/com/app/tibibalance/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/settings/SettingsScreen.kt
@@ -81,6 +81,7 @@ fun SettingsScreen(
     Box(
         Modifier
             .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing)
             .background(gradient)
     ) {
         ReadyContent(

--- a/app/src/main/java/com/app/tibibalance/ui/screens/settings/notification/ConfigureNotificationScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/settings/notification/ConfigureNotificationScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -58,6 +60,7 @@ fun ConfigureNotificationScreen(
     Box(
         Modifier
             .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing)
             .background(gradient)
     ) {
         when (ui) {

--- a/app/src/main/java/com/app/tibibalance/ui/screens/settings/notification/ModalConfigNotification.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/settings/notification/ModalConfigNotification.kt
@@ -36,7 +36,11 @@ fun ModalConfigNotification(
             .fillMaxWidth()
             .heightIn(max = LocalConfiguration.current.screenHeightDp.dp * .85f)
     ) {
-        Column(Modifier.fillMaxSize()) {
+        Column(
+            Modifier
+                .fillMaxSize()
+                .windowInsetsPadding(WindowInsets.safeDrawing)
+        ) {
 
             /* -------- cuerpo reutilizado -------- */
             Box(Modifier.weight(1f)) {


### PR DESCRIPTION
## Summary
- ensure screens apply `WindowInsets.safeDrawing` padding when using `fillMaxSize`

## Testing
- `./gradlew test` *(fails: No route to host)*