### PR TITLE
Add daily metrics use cases

### DIFF
--- a/domain/src/main/java/com/app/domain/usecase/metrics/CountPendingMetricsUseCase.kt
+++ b/domain/src/main/java/com/app/domain/usecase/metrics/CountPendingMetricsUseCase.kt
@@ -1,0 +1,11 @@
+package com.app.domain.usecase.metrics
+
+import com.app.domain.repository.MetricsRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class CountPendingMetricsUseCase @Inject constructor(
+    private val repo: MetricsRepository
+) {
+    operator fun invoke(): Flow<Int> = repo.countPending()
+}

--- a/domain/src/main/java/com/app/domain/usecase/metrics/ObserveDailyMetricsUseCase.kt
+++ b/domain/src/main/java/com/app/domain/usecase/metrics/ObserveDailyMetricsUseCase.kt
@@ -1,0 +1,12 @@
+package com.app.domain.usecase.metrics
+
+import com.app.domain.model.DailyMetrics
+import com.app.domain.repository.MetricsRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class ObserveDailyMetricsUseCase @Inject constructor(
+    private val repo: MetricsRepository
+) {
+    operator fun invoke(): Flow<List<DailyMetrics>> = repo.streamDailyMetrics()
+}


### PR DESCRIPTION
## Summary
- add ObserveDailyMetricsUseCase
- add CountPendingMetricsUseCase

## Testing
- `./gradlew test --no-daemon` *(fails: Cannot find a Java installation)*

------
https://chatgpt.com/codex/tasks/task_e_68428ee99638832d94b8c60adf80141b