### PR TITLE
Implement HabitUpdate handling from Wear

### DIFF
--- a/app/src/main/java/com/app/tibibalance/wear/MobileWearDataReceiver.kt
+++ b/app/src/main/java/com/app/tibibalance/wear/MobileWearDataReceiver.kt
@@ -3,7 +3,9 @@ package com.app.tibibalance.wear
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import com.app.domain.repository.MetricsRepository
+import com.app.domain.repository.HabitActivityRepository
 import com.app.domain.model.DailyMetrics
+import com.app.domain.enums.ActivityStatus
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -13,10 +15,12 @@ import com.google.android.gms.wearable.DataEvent
 import com.google.android.gms.wearable.DataEventBuffer
 import com.google.android.gms.wearable.DataMapItem
 import com.google.android.gms.wearable.WearableListenerService
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
+import com.app.data.remote.model.HabitUpdatePayload
 
 @AndroidEntryPoint
 class MobileWearDataReceiver : WearableListenerService() {
@@ -33,6 +37,9 @@ class MobileWearDataReceiver : WearableListenerService() {
     @Inject
     lateinit var metricsRepository: MetricsRepository
 
+    @Inject
+    lateinit var habitActivityRepository: HabitActivityRepository
+
     override fun onDataChanged(dataEvents: DataEventBuffer) {
 
         Log.d(TAG, "onDataChanged ► se invocó con ${dataEvents.count()} evento(s)")
@@ -42,12 +49,6 @@ class MobileWearDataReceiver : WearableListenerService() {
             val path = event.dataItem.uri.path
             Log.d(TAG, "DataEvent recibido con path: $path")
 
-            // Solo procesamos /tibibalance/metrics
-            if (path != "/tibibalance/metrics") {
-                Log.d(TAG, "Se ignora path [$path]")
-                continue
-            }
-
             val dataMap = DataMapItem.fromDataItem(event.dataItem).dataMap
             val payloadJson = dataMap.getString("payload_json")
             if (payloadJson == null) {
@@ -55,36 +56,70 @@ class MobileWearDataReceiver : WearableListenerService() {
                 continue
             }
 
+            when (path) {
+                "/tibibalance/metrics" -> {
+                    try {
+                        val payload = json.decodeFromString<DailyMetricsPayload>(payloadJson)
 
-            try {
-                // 1) Convertimos el JSON al DTO (DailyMetricsPayload):
-                val payload = json.decodeFromString<DailyMetricsPayload>(payloadJson)
+                        val instant = Instant.fromEpochMilliseconds(payload.timestamp)
+                        val date = instant
+                            .toLocalDateTime(TimeZone.currentSystemDefault())
+                            .date
 
-                // 2) Mapeamos el DTO a nuestro modelo de dominio (DailyMetrics):
-                val instant = Instant.fromEpochMilliseconds(payload.timestamp)
-                val date = instant
-                    .toLocalDateTime(TimeZone.currentSystemDefault())
-                    .date
+                        val domainMetrics = DailyMetrics(
+                            date = date,
+                            steps = payload.steps,
+                            avgHeart = payload.heartRate?.toInt(),
+                            calories = payload.caloriesBurned?.toInt(),
+                            source = "wear_os",
+                            importedAt = instant,
+                            pendingSync = true
+                        )
 
-                val domainMetrics = DailyMetrics(
-                    date = date,
-                    steps = payload.steps,
-                    avgHeart = payload.heartRate?.toInt(),
-                    calories = payload.caloriesBurned?.toInt(),
-                    source = "wear_os",
-                    importedAt = instant,
-                    pendingSync = true
-                )
-
-                // 3) Guardamos la métrica en Room a través de MetricsRepository
-                ioScope.launch {
-                    metricsRepository.upsert(domainMetrics)
-                    Log.i(TAG, "Métricas guardadas en Room [date=$date]")
+                        ioScope.launch {
+                            metricsRepository.upsert(domainMetrics)
+                            Log.i(TAG, "Métricas guardadas en Room [date=$date]")
+                        }
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Error deserializando o guardando DailyMetricsPayload: $e")
+                    }
                 }
-            } catch (e: Exception) {
-                Log.e(TAG, "Error deserializando o guardando DailyMetricsPayload: $e")
-            }
 
+                "/tibibalance/habit_update" -> {
+                    try {
+                        val payload = json.decodeFromString<HabitUpdatePayload>(payloadJson)
+                        val instant = Instant.fromEpochMilliseconds(payload.timestamp)
+                        val date = instant
+                            .toLocalDateTime(TimeZone.currentSystemDefault())
+                            .date
+
+                        ioScope.launch {
+                            val activities = habitActivityRepository.observeByDate(date).first()
+                            val activity = activities.find { it.habitId.raw == payload.habitId }
+                            if (activity != null) {
+                                val updated = activity.copy(
+                                    status = if (payload.isCompleted) ActivityStatus.COMPLETED else ActivityStatus.PENDING,
+                                    loggedAt = if (payload.isCompleted) instant else null,
+                                    meta = activity.meta.copy(
+                                        updatedAt = Instant.fromEpochMilliseconds(System.currentTimeMillis()),
+                                        pendingSync = true
+                                    )
+                                )
+                                habitActivityRepository.update(updated)
+                                Log.i(TAG, "Actividad actualizada desde Wear [habitId=${payload.habitId}]")
+                            } else {
+                                Log.w(TAG, "Actividad no encontrada para habitId=${payload.habitId} en fecha $date")
+                            }
+                        }
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Error procesando HabitUpdatePayload: $e")
+                    }
+                }
+
+                else -> {
+                    Log.d(TAG, "Se ignora path [$path]")
+                }
+            }
         }
     }
 }

--- a/data/src/main/java/com/app/data/remote/model/HabitUpdatePayload.kt
+++ b/data/src/main/java/com/app/data/remote/model/HabitUpdatePayload.kt
@@ -1,0 +1,10 @@
+package com.app.data.remote.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HabitUpdatePayload(
+    val habitId: String,
+    val isCompleted: Boolean,
+    val timestamp: Long
+)


### PR DESCRIPTION
## Summary
- listen for `/tibibalance/habit_update` events
- deserialize `HabitUpdatePayload`
- update today's `HabitActivity` via repository
- expose `HabitUpdatePayload` model for the app

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68428ef14ea0832db81488dfd56941f2