### PR TITLE
Implementa vista de métricas y corrige Worker

### DIFF
--- a/app/src/main/java/com/app/tibibalance/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/navigation/AppNavGraph.kt
@@ -24,6 +24,7 @@ import com.app.tibibalance.ui.screens.settings.devices.ManageDevicesScreen
 import com.app.tibibalance.ui.screens.settings.achievements.AchievementsScreen
 import com.app.tibibalance.ui.screens.settings.notification.ConfigureNotificationScreen
 import com.app.tibibalance.ui.screens.delete.GoodbyeScreen
+import com.app.tibibalance.ui.screens.metrics.MetricsListScreen
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
@@ -53,6 +54,7 @@ fun AppNavGraph(navController: NavHostController = rememberNavController()) {
         composable(Screen.ConfigureNotif.route) { ConfigureNotificationScreen(navController) }
         composable(Screen.ManageDevices.route) { ManageDevicesScreen(navController = navController) }
         composable(Screen.Achievements.route) { AchievementsScreen(onNavigateUp = { navController.popBackStack() }) }
+        composable(Screen.Metrics.route) { MetricsListScreen(navController = navController) }
         composable(Screen.Goodbye.route) {
             GoodbyeScreen(navController = navController)
         }

--- a/app/src/main/java/com/app/tibibalance/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/navigation/Screen.kt
@@ -76,5 +76,7 @@ data object Habits              : Screen("main/habits")
     data object ChangePassword  : Screen("change_password")
     data object ConfigureNotif  : Screen("configure_notif")
     data object Achievements : Screen("achievements")
+    /** Pantalla con la lista de métricas almacenadas localmente. */
+    data object Metrics       : Screen("metrics_list")
     data object Goodbye : Screen("goodbye")
 }

--- a/app/src/main/java/com/app/tibibalance/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/home/HomeScreen.kt
@@ -13,6 +13,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavHostController
+import androidx.compose.material3.Button
+import com.app.tibibalance.ui.navigation.Screen
 import com.app.domain.entities.DailyTip
 import com.app.tibibalance.ui.components.containers.DailyTip
 import com.app.tibibalance.ui.components.texts.Title // drawables / colores
@@ -26,6 +29,7 @@ private const val PAGES = 2     // Tip · Métricas
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun HomeScreen(
+    navController: NavHostController,
     viewModel: HomeViewModel = hiltViewModel()
 ) {
     val state      by viewModel.ui.collectAsState()
@@ -51,7 +55,7 @@ fun HomeScreen(
         ) { page ->
             when (page) {
                 0 -> TipPage(state.dailyTip)
-                1 -> MetricsPage()
+                1 -> MetricsPage(navController)
             }
         }
 
@@ -92,7 +96,7 @@ private fun TipPage(
 
 /* -------------- Página 1: Métricas ------------------- */
 @Composable
-private fun MetricsPage() {
+private fun MetricsPage(navController: NavHostController) {
     Column(
         Modifier
             .fillMaxSize()
@@ -105,7 +109,13 @@ private fun MetricsPage() {
            ⚠️ Aún NO depende de isWatchConnected; se mostrará siempre.
            Cuando implementes la lógica, ocúltalo cuando `watchConnected == true`. */
         ConnectWatchCard(
-            onClick = { /* TODO: navegar a flujo de enlace */ }
+            onClick = { navController.navigate(Screen.ManageDevices.route) }
         )
+
+        Button(
+            onClick = { navController.navigate(Screen.Metrics.route) }
+        ) {
+            Text("Historial")
+        }
     }
 }

--- a/app/src/main/java/com/app/tibibalance/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/main/MainScreen.kt
@@ -50,7 +50,7 @@ fun MainScreen(rootNav: NavHostController) {
             startDestination = Screen.Home.route,
             modifier = Modifier.padding(padding)
         ) {
-            composable(Screen.Home.route)     { HomeScreen() }
+            composable(Screen.Home.route)     { HomeScreen(rootNav) }
             composable(Screen.Emotions.route) { EmotionalCalendarScreen() }
             composable(Screen.Habits.route)   { HabitsScreen() }
             composable(Screen.Profile.route)  { ViewProfileScreen(rootNav) }

--- a/app/src/main/java/com/app/tibibalance/ui/screens/metrics/MetricsListScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/metrics/MetricsListScreen.kt
@@ -1,0 +1,63 @@
+package com.app.tibibalance.ui.screens.metrics
+
+/**
+ * @file MetricsListScreen.kt
+ * @brief Interfaz de Jetpack Compose para mostrar las métricas guardadas.
+ */
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.icons.Icons
+import androidx.compose.material3.icons.filled.ArrowBack
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.app.domain.entities.DailyMetrics
+
+/**
+ * @file MetricsListScreen.kt
+ * @brief Pantalla que muestra las métricas almacenadas.
+ */
+@Composable
+fun MetricsListScreen(
+    navController: NavHostController,
+    viewModel: MetricsViewModel = hiltViewModel()
+) {
+    val metrics by viewModel.metrics.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Historial") },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Atrás")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        LazyColumn(modifier = Modifier.padding(padding)) {
+            items(metrics) { item -> MetricRow(item) }
+        }
+    }
+}
+
+@Composable
+private fun MetricRow(metric: DailyMetrics) {
+    ListItem(
+        headlineText = { Text(metric.date.toString()) },
+        supportingText = { Text("Pasos: ${metric.steps}") }
+    )
+}
+

--- a/app/src/main/java/com/app/tibibalance/ui/screens/metrics/MetricsViewModel.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/metrics/MetricsViewModel.kt
@@ -1,0 +1,26 @@
+package com.app.tibibalance.ui.screens.metrics
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.app.domain.entities.DailyMetrics
+import com.app.domain.usecase.metrics.ObserveDailyMetricsUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+/**
+ * @file MetricsViewModel.kt
+ * @brief ViewModel que expone las métricas almacenadas en Room.
+ */
+@HiltViewModel
+class MetricsViewModel @Inject constructor(
+    observeDailyMetricsUseCase: ObserveDailyMetricsUseCase
+) : ViewModel() {
+
+    /** Flujo de métricas listo para ser observado por la UI. */
+    val metrics: StateFlow<List<DailyMetrics>> =
+        observeDailyMetricsUseCase()
+            .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+}

--- a/data/src/androidTest/java/com/app/data/db/MigrationTest.kt
+++ b/data/src/androidTest/java/com/app/data/db/MigrationTest.kt
@@ -1,0 +1,47 @@
+package com.app.data.db
+
+import android.content.Context
+import androidx.room.Room
+import androidx.room.testing.MigrationTestHelper
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.app.data.local.db.AppDb
+import com.app.data.local.db.MIGRATION_1_2
+import com.app.data.local.db.MIGRATION_2_3
+import net.sqlcipher.database.SupportFactory
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+
+/**
+ * @file MigrationTest.kt
+ * @brief Verifica que las migraciones de Room se ejecutan correctamente.
+ */
+@RunWith(AndroidJUnit4::class)
+class MigrationTest {
+
+    @get:Rule
+    val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        AppDb::class.java.canonicalName
+    )
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate1To3() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val dbName = "test-db"
+
+        // Crea base versión 1
+        helper.createDatabase(dbName, 1).apply { close() }
+
+        // Abre base con migraciones 1_2 y 2_3
+        Room.databaseBuilder(context, AppDb::class.java, dbName)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+            .openHelperFactory(SupportFactory(byteArrayOf()))
+            .build()
+            .apply { close() }
+    }
+}

--- a/data/src/main/java/com/app/data/di/WorkerModule.kt
+++ b/data/src/main/java/com/app/data/di/WorkerModule.kt
@@ -1,6 +1,11 @@
 // data/src/main/java/com/app/data/di/WorkerModule.kt
 package com.app.data.di
-/*
+
+/**
+ * @file WorkerModule.kt
+ * @brief Proporciona el ChildWorkerFactory para MetricsSyncWorker.
+ */
+
 import com.app.data.worker.ChildWorkerFactory
 import com.app.data.worker.MetricsSyncWorkerChildFactory
 import dagger.Binds
@@ -19,4 +24,3 @@ abstract class WorkerModule {
         factory: MetricsSyncWorkerChildFactory
     ): ChildWorkerFactory
 }
-*/

--- a/data/src/main/java/com/app/data/worker/MetricsSyncWorkerChildFactory.kt
+++ b/data/src/main/java/com/app/data/worker/MetricsSyncWorkerChildFactory.kt
@@ -1,6 +1,11 @@
 // data/src/main/java/com/app/data/worker/MetricsSyncWorkerChildFactory.kt
 package com.app.data.worker
-/*
+
+/**
+ * @file MetricsSyncWorkerChildFactory.kt
+ * @brief Adaptador que registra el Factory asistido del Worker.
+ */
+
 import android.content.Context
 import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
@@ -10,6 +15,7 @@ import javax.inject.Inject
  * Adaptador que expone MetricsSyncWorker.Factory como ChildWorkerFactory,
  * de forma que el WorkerFactory global pueda instanciarlo.
  */
+
 class MetricsSyncWorkerChildFactory @Inject constructor(
     private val assistedFactory: MetricsSyncWorker.Factory
 ) : ChildWorkerFactory {
@@ -19,4 +25,3 @@ class MetricsSyncWorkerChildFactory @Inject constructor(
         return assistedFactory.create(appContext, params)
     }
 }
-*/

--- a/data/src/test/java/com/app/data/converters/DateTimeConvertersTest.kt
+++ b/data/src/test/java/com/app/data/converters/DateTimeConvertersTest.kt
@@ -1,0 +1,39 @@
+package com.app.data.converters
+
+import com.app.data.local.converters.DateTimeConverters
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalTime
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * @file DateTimeConvertersTest.kt
+ * @brief Pruebas unitarias para los convertidores de fecha y hora.
+ */
+class DateTimeConvertersTest {
+
+    @Test
+    fun instantRoundTrip() {
+        val now = Instant.fromEpochMilliseconds(1234567890)
+        val long = DateTimeConverters.instantToLong(now)
+        val restored = DateTimeConverters.longToInstant(long)
+        assertEquals(now, restored)
+    }
+
+    @Test
+    fun localDateRoundTrip() {
+        val date = LocalDate.parse("2024-01-01")
+        val str = DateTimeConverters.localDateToString(date)
+        val back = DateTimeConverters.stringToLocalDate(str)
+        assertEquals(date, back)
+    }
+
+    @Test
+    fun localTimeRoundTrip() {
+        val time = LocalTime.parse("08:30")
+        val str = DateTimeConverters.localTimeToString(time)
+        val back = DateTimeConverters.stringToLocalTime(str)
+        assertEquals(time, back)
+    }
+}

--- a/domain/src/main/java/com/app/domain/usecase/metrics/ObserveDailyMetricsUseCase.kt
+++ b/domain/src/main/java/com/app/domain/usecase/metrics/ObserveDailyMetricsUseCase.kt
@@ -1,6 +1,14 @@
 package com.app.domain.usecase.metrics
 
-import com.app.domain.model.DailyMetrics
+/**
+ * @file ObserveDailyMetricsUseCase.kt
+ * @brief Caso de uso que expone un flujo con todas las métricas almacenadas.
+ *
+ * Utiliza el [MetricsRepository] para obtener de Room la lista de
+ * [DailyMetrics] y entregarla como [Flow].
+ */
+
+import com.app.domain.entities.DailyMetrics
 import com.app.domain.repository.MetricsRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject

--- a/wear/src/main/java/com/app/wear/data/datasource/HealthServicesSensorDataSource.kt
+++ b/wear/src/main/java/com/app/wear/data/datasource/HealthServicesSensorDataSource.kt
@@ -69,7 +69,18 @@ class HealthServicesSensorDataSource @Inject constructor(
     }
 
     /* ──────────── Pasos diarios ──────────── */
-    override suspend fun fetchCurrentStepCount(): Int = 0
+    override suspend fun fetchCurrentStepCount(): Int {
+        return try {
+            val data = measureClient.getCurrentData(DataType.STEP_COUNT_TOTAL)
+            data.getData(DataType.STEP_COUNT_TOTAL)
+                .lastOrNull()
+                ?.value
+                ?.roundToInt()
+                ?: 0
+        } catch (e: Exception) {
+            0
+        }
+    }
 
     /* ───────── util ───────── */
     private fun hasPerm(p: String) =

--- a/wear/src/main/java/com/app/wear/data/datasource/WearableApiCommDataSource.kt
+++ b/wear/src/main/java/com/app/wear/data/datasource/WearableApiCommDataSource.kt
@@ -17,8 +17,8 @@ class WearableApiCommDataSource @Inject constructor(
 
     companion object {
         private const val TAG = "WearableApiCommDS"
-        // Paths para la Data Layer API (deben ser únicos y consistentes con la app móvil)
-        private const val METRICS_DATA_PATH = "/tibibalance/metrics"
+        // Paths para la Data Layer API (deben ser consistentes con MobileWearDataReceiver)
+        private const val METRICS_DATA_PATH = "/tibibalance/metrics" // ↔ móvil
         private const val HABIT_UPDATE_DATA_PATH = "/tibibalance/habit_update"
 
         // Keys para los DataMap

--- a/wear/src/main/java/com/app/wear/presentation/viewmodel/WearMetricsViewModel.kt
+++ b/wear/src/main/java/com/app/wear/presentation/viewmodel/WearMetricsViewModel.kt
@@ -1,5 +1,10 @@
 package com.app.wear.presentation.viewmodel
 
+/**
+ * @file WearMetricsViewModel.kt
+ * @brief ViewModel que gestiona la recolección y el envío de métricas desde el reloj.
+ */
+
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -114,11 +119,11 @@ class WearMetricsViewModel @Inject constructor(
             )*/
 
             val metricsData = WearableDailyMetrics(
-                steps = 123,
-                heartRate = 70f,
-                caloriesBurned = calculateCaloriesBurned(123),
-                activeMinutes = calculateActiveMinutes(123),
-                distanceMeters = calculateDistance(123),
+                steps = currentSteps,
+                heartRate = currentHeartRate?.toFloat(),
+                caloriesBurned = calculateCaloriesBurned(currentSteps),
+                activeMinutes = calculateActiveMinutes(currentSteps),
+                distanceMeters = calculateDistance(currentSteps),
                 timestamp = System.currentTimeMillis(),
                 userId = userId
             )

--- a/wear/src/test/java/com/app/wear/data/mapper/MetricsMapperTest.kt
+++ b/wear/src/test/java/com/app/wear/data/mapper/MetricsMapperTest.kt
@@ -1,0 +1,29 @@
+package com.app.wear.data.mapper
+
+import com.app.wear.domain.model.WearableDailyMetrics
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * @file MetricsMapperTest.kt
+ * @brief Pruebas para la conversión de métricas del dominio al payload.
+ */
+class MetricsMapperTest {
+    @Test
+    fun toPayload_mapsFields() {
+        val domain = WearableDailyMetrics(
+            steps = 10,
+            heartRate = 70f,
+            caloriesBurned = 1f,
+            activeMinutes = 2,
+            distanceMeters = 3f,
+            timestamp = 1000L,
+            userId = "u"
+        )
+
+        val dto = domain.toPayload()
+        assertEquals(domain.steps, dto.steps)
+        assertEquals(domain.heartRate, dto.heartRate)
+        assertEquals(domain.timestamp, dto.timestamp)
+    }
+}


### PR DESCRIPTION
## Resumen
- se corrige import en `ObserveDailyMetricsUseCase`
- se habilitan `WorkerModule` y `MetricsSyncWorkerChildFactory`
- se crea `MetricsViewModel` y pantalla `MetricsListScreen`
- se actualiza navegación y Home para acceder al historial
- se completa `WearMetricsViewModel` usando datos reales
- se añade test de migraciones y convertidores

## Testing
- `./gradlew test` *(falla: no se encontró JDK 17)*

------
https://chatgpt.com/codex/tasks/task_e_6842ed4ac54c8329a1576fdf27d6fcca