### PR TITLE
Add tutorial scaffolding

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
     implementation(libs.lottie.compose)
     implementation(libs.accompanist.permissions)
     implementation(libs.spinwheel.compose)
+    implementation(libs.tap.target.compose)
 
     /* ── Room (local DB) ────────────────────────────── */
     implementation(libs.room.runtime)

--- a/app/src/main/java/com/app/tibibalance/ui/TibiBalanceRoot.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/TibiBalanceRoot.kt
@@ -9,14 +9,20 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.app.tibibalance.ui.navigation.AppNavGraph
 import com.app.tibibalance.ui.theme.AppThemeViewModel
 import com.app.tibibalance.ui.theme.TibiBalanceTheme
+import com.app.tibibalance.ui.tutorial.TutorialOverlay
+import com.app.tibibalance.ui.tutorial.TutorialViewModel
+import com.app.tibibalance.ui.tutorial.tutorialTarget
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun TibiBalanceRoot() {
     val themeVm: AppThemeViewModel = hiltViewModel()
+    val tutorialVm: TutorialViewModel = hiltViewModel()
     val mode   = themeVm.mode.collectAsState().value
+    val step   = tutorialVm.currentStep.collectAsState().value
 
     TibiBalanceTheme(mode = mode) {
         AppNavGraph()
+        TutorialOverlay(step = step, onNext = tutorialVm::proceedToNextStep, onSkip = tutorialVm::skipTutorial)
     }
 }

--- a/app/src/main/java/com/app/tibibalance/ui/components/buttons/NavBarButton.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/components/buttons/NavBarButton.kt
@@ -62,13 +62,15 @@ import com.app.tibibalance.ui.components.navigation.BottomNavItem
 fun NavBarButton(
     item: BottomNavItem,
     selected: Boolean,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    tutorialStep: TutorialStepData? = null
 ) {
     // Contenedor principal del botón, define el tamaño y la acción de clic
     Box(
         modifier = Modifier
             .size(75.dp) // Tamaño fijo para el área del botón
-            .clickable(onClick = onClick), // Hace todo el Box clicable
+            .clickable(onClick = onClick)
+            .tutorialTarget(tutorialStep, item.route),
         contentAlignment = Alignment.Center // Centra el contenido (la Columna)
     ) {
         // Fondo de realce, visible solo si 'selected' es true

--- a/app/src/main/java/com/app/tibibalance/ui/components/navigation/BottomNavBar.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/components/navigation/BottomNavBar.kt
@@ -87,7 +87,8 @@ fun BottomNavBar(
                 NavBarButton(
                     item = item,
                     selected = item.route == selectedRoute,
-                    onClick = { onItemClick(item.route) }
+                    onClick = { onItemClick(item.route) },
+                    tutorialStep = null
                 )
             }
         }

--- a/app/src/main/java/com/app/tibibalance/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/home/HomeScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -20,6 +22,9 @@ import com.app.tibibalance.ui.components.containers.ConnectWatchCard
 import com.app.tibibalance.ui.screens.home.activities.ActivityFeed
 import com.app.tibibalance.ui.components.utils.PagerIndicator
 import com.app.tibibalance.ui.screens.home.activities.ActivityLogDialog
+import com.app.tibibalance.ui.tutorial.TutorialViewModel
+import com.app.tibibalance.ui.tutorial.tutorialTarget
+import com.app.tibibalance.ui.tutorial.TutorialStepData
 
 private const val PAGES = 2     // Tip · Métricas
 
@@ -27,7 +32,8 @@ private const val PAGES = 2     // Tip · Métricas
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun HomeScreen(
-    viewModel: HomeViewModel = hiltViewModel()
+    viewModel: HomeViewModel = hiltViewModel(),
+    tutorialVm: TutorialViewModel = hiltViewModel()
 ) {
     val state      by viewModel.ui.collectAsState()
     val pagerState = rememberPagerState(initialPage = 0, pageCount = { 2 })
@@ -39,6 +45,9 @@ fun HomeScreen(
             .padding(top = 8.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
+        androidx.compose.material3.IconButton(onClick = tutorialVm::restartTutorial) {
+            androidx.compose.material3.Icon(Icons.Default.Info, contentDescription = "Ayuda")
+        }
         /* Saludo */
         Title("¡Hola de nuevo! ${state.user?.displayName.orEmpty()}")
 
@@ -51,7 +60,7 @@ fun HomeScreen(
                 .fillMaxWidth()
         ) { page ->
             when (page) {
-                0 -> TipPage(state.dailyTip)
+                0 -> TipPage(state.dailyTip, tutorialVm.currentStep.collectAsState().value)
                 1 -> MetricsPage()
             }
         }
@@ -88,10 +97,11 @@ fun HomeScreen(
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 private fun TipPage(
-    tip: DailyTip?
+    tip: DailyTip?,
+    step: TutorialStepData?
 ) {
     if (tip != null) {
-        DailyTip(tip = tip)
+        DailyTip(tip = tip, modifier = Modifier.tutorialTarget(step, "daily_tip_card"))
     } else {
         // Fallback cuando no hay tip disponible (raro)
         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.TopStart) {

--- a/app/src/main/java/com/app/tibibalance/ui/tutorial/TutorialOverlay.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/tutorial/TutorialOverlay.kt
@@ -1,0 +1,45 @@
+package com.app.tibibalance.ui.tutorial
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.psoffritti.taptargetcompose.TapTargetCoordinator
+import com.psoffritti.taptargetcompose.tapTarget
+import com.psoffritti.taptargetcompose.TapTargetDefinition
+import com.psoffritti.taptargetcompose.TextDefinition
+import com.psoffritti.taptargetcompose.TapTargetStyle
+
+@Composable
+fun TutorialOverlay(
+    step: TutorialStepData?,
+    onNext: () -> Unit,
+    onSkip: () -> Unit
+) {
+    if (step == null) return
+
+    TapTargetCoordinator(showTapTargets = true, onComplete = {}) {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.BottomCenter) {
+            Box(Modifier.align(Alignment.BottomCenter)) {
+                Button(onClick = onNext) { Text("Siguiente") }
+                Button(onClick = onSkip) { Text("Omitir") }
+            }
+        }
+    }
+}
+
+fun Modifier.tutorialTarget(current: TutorialStepData?, id: String): Modifier {
+    return if (current != null && current.targetId == id) {
+        this.tapTarget(
+            TapTargetDefinition(
+                precedence = 0,
+                title = TextDefinition(current.title),
+                description = TextDefinition(current.message),
+                tapTargetStyle = TapTargetStyle()
+            )
+        )
+    } else this
+}

--- a/app/src/main/java/com/app/tibibalance/ui/tutorial/TutorialStep.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/tutorial/TutorialStep.kt
@@ -1,0 +1,105 @@
+package com.app.tibibalance.ui.tutorial
+
+sealed class TutorialStep(val data: TutorialStepData) {
+    data object Intro : TutorialStep(
+        TutorialStepData(
+            id = "intro",
+            title = "¡Bienvenido a TibiBalance!",
+            message = "Conoce lo básico para empezar",
+            targetId = null
+        )
+    )
+
+    data object HabitsTab : TutorialStep(
+        TutorialStepData(
+            id = "habits_tab",
+            title = "Empieza a Crear Hábitos",
+            message = "Aquí gestionarás todos tus hábitos",
+            targetId = "habits_tab"
+        )
+    )
+
+    data object CreateHabit : TutorialStep(
+        TutorialStepData(
+            id = "create_habit",
+            title = "Crea Tu Primer Hábito",
+            message = "Toca aquí para añadir un nuevo hábito",
+            targetId = "habit_fab"
+        )
+    )
+
+    data object DailyProgress : TutorialStep(
+        TutorialStepData(
+            id = "daily_progress",
+            title = "Tu Progreso Diario",
+            message = "Aquí verás un resumen de tu progreso diario",
+            targetId = "daily_progress_card"
+        )
+    )
+
+    data object ActivityFab : TutorialStep(
+        TutorialStepData(
+            id = "activity_fab",
+            title = "Registra tus Actividades",
+            message = "Toca este botón para registrar una actividad completada",
+            targetId = "activity_fab"
+        )
+    )
+
+    data object DailyTip : TutorialStep(
+        TutorialStepData(
+            id = "daily_tip",
+            title = "Consejos Diarios",
+            message = "Obtén un consejo diario para mantener tu motivación",
+            targetId = "daily_tip_card"
+        )
+    )
+
+    data object Stats : TutorialStep(
+        TutorialStepData(
+            id = "stats_section",
+            title = "Analiza tu Progreso",
+            message = "Explora tus estadísticas y visualiza tu progreso",
+            targetId = "stats_section"
+        )
+    )
+
+    data object Profile : TutorialStep(
+        TutorialStepData(
+            id = "profile_section",
+            title = "Accede a tu Perfil",
+            message = "En tu perfil, puedes editar tu información",
+            targetId = "profile_section"
+        )
+    )
+
+    data object Settings : TutorialStep(
+        TutorialStepData(
+            id = "settings_section",
+            title = "Ajustes Generales",
+            message = "Personaliza la aplicación a tu gusto",
+            targetId = "settings_section"
+        )
+    )
+
+    data object Final : TutorialStep(
+        TutorialStepData(
+            id = "final",
+            title = "¡Eso es todo por ahora!",
+            message = "Disfruta usando TibiBalance",
+            targetId = null
+        )
+    )
+
+    companion object {
+        val all = listOf(Intro, HabitsTab, CreateHabit, DailyProgress, ActivityFab, DailyTip, Stats, Profile, Settings, Final)
+    }
+}
+
+data class TutorialStepData(
+    val id: String,
+    val title: String,
+    val message: String,
+    val targetId: String?,
+    val conditionalCheck: (suspend () -> Boolean)? = null
+)

--- a/app/src/main/java/com/app/tibibalance/ui/tutorial/TutorialViewModel.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/tutorial/TutorialViewModel.kt
@@ -1,0 +1,68 @@
+package com.app.tibibalance.ui.tutorial
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.app.domain.repository.AuthRepository
+import com.app.domain.usecase.onboarding.ObserveOnboardingStatus
+import com.app.domain.usecase.tutorial.SaveTutorialStatusUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class TutorialViewModel @Inject constructor(
+    private val authRepo: AuthRepository,
+    private val observeStatus: ObserveOnboardingStatus,
+    private val saveStatus: SaveTutorialStatusUseCase
+) : ViewModel() {
+
+    private val _currentStep = MutableStateFlow<TutorialStepData?>(null)
+    val currentStep: StateFlow<TutorialStepData?> = _currentStep
+
+    private val steps = TutorialStep.all
+    private var index = -1
+
+    init { startIfNeeded() }
+
+    private fun startIfNeeded() {
+        viewModelScope.launch {
+            val uid = authRepo.authState().first() ?: return@launch
+            val status = observeStatus(uid).first()
+            if (status.tutorialCompleted && !status.hasCompletedTutorial) {
+                proceedToNextStep()
+            }
+        }
+    }
+
+    fun proceedToNextStep() {
+        viewModelScope.launch {
+            do {
+                index++
+                if (index >= steps.size) { finishTutorial(); return@launch }
+                val step = steps[index]
+                val show = step.data.conditionalCheck?.invoke() ?: true
+            } while (!show)
+            _currentStep.value = steps[index].data
+        }
+    }
+
+    fun skipTutorial() {
+        viewModelScope.launch {
+            finishTutorial()
+        }
+    }
+
+    fun restartTutorial() {
+        index = -1
+        proceedToNextStep()
+    }
+
+    private suspend fun finishTutorial() {
+        _currentStep.value = null
+        val uid = authRepo.authState().first() ?: return
+        saveStatus(uid, true)
+    }
+}

--- a/data/src/main/java/com/app/data/local/db/AppDb.kt
+++ b/data/src/main/java/com/app/data/local/db/AppDb.kt
@@ -29,7 +29,7 @@ import com.app.data.local.entities.UserEntity
         DailyMetricsEntity::class, OnboardingStatusEntity::class,
         DailyTipEntity::class
     ],
-    version = 2,
+    version = 4,
     exportSchema = true
 )
 @TypeConverters(

--- a/data/src/main/java/com/app/data/local/db/Migrations.kt
+++ b/data/src/main/java/com/app/data/local/db/Migrations.kt
@@ -18,3 +18,10 @@ val MIGRATION_2_3 = object : Migration(2, 3) {
         db.execSQL("""CREATE INDEX IF NOT EXISTS index_activities_timestamp ON activities(timestamp)""")
     }
 }
+
+/** v3 → v4 · nueva columna hasCompletedTutorial */
+val MIGRATION_3_4 = object : Migration(3, 4) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE onboarding_status ADD COLUMN hasCompletedTutorial INTEGER NOT NULL DEFAULT 0")
+    }
+}

--- a/data/src/main/java/com/app/data/local/di/DatabaseModule.kt
+++ b/data/src/main/java/com/app/data/local/di/DatabaseModule.kt
@@ -33,7 +33,7 @@ object DatabaseModule {
     ): AppDb =
         Room.databaseBuilder(ctx, AppDb::class.java, "tibi.db")
             .openHelperFactory(factory)
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3)       // 👈 sustituye fallbackToDestructive
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)       // 👈 sustituye fallbackToDestructive
             .build()
 
 

--- a/data/src/main/java/com/app/data/local/entities/OnboardingStatusEntity.kt
+++ b/data/src/main/java/com/app/data/local/entities/OnboardingStatusEntity.kt
@@ -15,6 +15,7 @@ data class OnboardingStatusEntity(
     val tutorialCompleted            : Boolean,
     val legalAccepted                : Boolean,
     val permissionsAsked             : Boolean,
+    val hasCompletedTutorial         : Boolean,
     val completedAt                  : Instant?,
     @Embedded(prefix = "m_")      val meta: SyncMeta
 )

--- a/data/src/main/java/com/app/data/mappers/OnboardingMapper.kt
+++ b/data/src/main/java/com/app/data/mappers/OnboardingMapper.kt
@@ -15,6 +15,7 @@ object OnboardingMappers {
         tutorialCompleted = tutorialCompleted,
         legalAccepted     = legalAccepted,
         permissionsAsked  = permissionsAsked,
+        hasCompletedTutorial = hasCompletedTutorial,
         completedAt       = completedAt,
         meta              = meta
     )
@@ -26,6 +27,7 @@ object OnboardingMappers {
             tutorialCompleted = tutorialCompleted,
             legalAccepted     = legalAccepted,
             permissionsAsked  = permissionsAsked,
+            hasCompletedTutorial = hasCompletedTutorial,
             completedAt       = completedAt,
             meta              = meta
         )

--- a/data/src/main/java/com/app/data/remote/firebase/OnboardingFirestoreService.kt
+++ b/data/src/main/java/com/app/data/remote/firebase/OnboardingFirestoreService.kt
@@ -33,6 +33,7 @@ class OnboardingFirestoreService @Inject constructor(
             tutorialCompleted = snap.getBoolean("tutorialCompleted") ?: false,
             legalAccepted     = snap.getBoolean("legalAccepted") ?: false,
             permissionsAsked  = snap.getBoolean("permissionsAsked") ?: false,
+            hasCompletedTutorial = snap.getBoolean("hasCompletedTutorial") ?: false,
             completedAt       = snap.getString("completedAt")?.let(Instant::parse),
             meta = SyncMeta(
                 updatedAt   = snap.getString("updatedAt")?.let(Instant::parse)

--- a/data/src/main/java/com/app/data/repository/OnboardingRepositoryImpl.kt
+++ b/data/src/main/java/com/app/data/repository/OnboardingRepositoryImpl.kt
@@ -48,10 +48,17 @@ class OnboardingRepositoryImpl @Inject constructor(
                     "tutorialCompleted" to status.tutorialCompleted,
                     "legalAccepted"     to status.legalAccepted,
                     "permissionsAsked"  to status.permissionsAsked,
+                    "hasCompletedTutorial" to status.hasCompletedTutorial,
                     "completedAt"       to status.completedAt?.toString(),
                     "updatedAt"         to status.meta.updatedAt.toString()
                 )
             )
+        }
+
+    override suspend fun saveTutorialStatus(uid: String, completed: Boolean) =
+        withContext(io) {
+            val current = dao.find(uid)?.toDomain() ?: OnboardingStatus()
+            dao.upsert(current.copy(hasCompletedTutorial = completed).toEntity(uid))
         }
 
     override suspend fun syncNow(uid: String): Result<Unit> = withContext(io) {
@@ -77,6 +84,7 @@ class OnboardingRepositoryImpl @Inject constructor(
                         "tutorialCompleted" to winner.tutorialCompleted,
                         "legalAccepted"     to winner.legalAccepted,
                         "permissionsAsked"  to winner.permissionsAsked,
+                        "hasCompletedTutorial" to winner.hasCompletedTutorial,
                         "completedAt"       to winner.completedAt?.toString(),
                         "updatedAt"         to winner.meta.updatedAt.toString()
                     )

--- a/domain/src/main/java/com/app/domain/entities/OnboardingStatus.kt
+++ b/domain/src/main/java/com/app/domain/entities/OnboardingStatus.kt
@@ -14,6 +14,7 @@ data class OnboardingStatus(
     val tutorialCompleted : Boolean = false,
     val legalAccepted     : Boolean = false,
     val permissionsAsked  : Boolean = false,
+    val hasCompletedTutorial: Boolean = false,
     val completedAt       : Instant? = null,
     val meta              : SyncMeta = SyncMeta()
 )

--- a/domain/src/main/java/com/app/domain/repository/OnboardingRepository.kt
+++ b/domain/src/main/java/com/app/domain/repository/OnboardingRepository.kt
@@ -23,5 +23,6 @@ interface OnboardingRepository {
      * Debe disparar la sincronización remota en la capa de datos.
      */
     suspend fun save(uid: String, status: OnboardingStatus)
+    suspend fun saveTutorialStatus(uid: String, completed: Boolean)
     suspend fun syncNow(uid: String): Result<Unit>
 }

--- a/domain/src/main/java/com/app/domain/usecase/tutorial/SaveTutorialStatusUseCase.kt
+++ b/domain/src/main/java/com/app/domain/usecase/tutorial/SaveTutorialStatusUseCase.kt
@@ -1,0 +1,12 @@
+package com.app.domain.usecase.tutorial
+
+import com.app.domain.repository.OnboardingRepository
+import javax.inject.Inject
+
+class SaveTutorialStatusUseCase @Inject constructor(
+    private val repo: OnboardingRepository
+) {
+    suspend operator fun invoke(uid: String, completed: Boolean) {
+        repo.saveTutorialStatus(uid, completed)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ coil                  = "3.2.0"
 lottie                = "6.6.6"
 accompanist           = "0.37.3"
 spinwheel             = "1.1.1"
+tap-target-compose    = "1.2.1"
 playServicesWearable  = "19.0.0"
 healthServices        = "1.0.0"
 wearCompose           = "1.4.1"
@@ -92,6 +93,7 @@ coil-network-okhttp      = { group = "io.coil-kt.coil3",           name = "coil-
 lottie-compose           = { group = "com.airbnb.android",         name = "lottie-compose",            version.ref = "lottie" }
 accompanist-permissions  = { group = "com.google.accompanist",     name = "accompanist-permissions",   version.ref = "accompanist" }
 spinwheel-compose        = { group = "com.github.commandiron",     name = "SpinWheelCompose",          version.ref = "spinwheel" }
+tap-target-compose       = { group = "com.pierfrancescosoffritti.taptargetcompose", name = "core", version.ref = "tap-target-compose" }
 
 room-runtime             = { group = "androidx.room",             name = "room-runtime",              version.ref = "room" }
 room-ktx                 = { group = "androidx.room",             name = "room-ktx",                  version.ref = "room" }


### PR DESCRIPTION
## Summary
- extend `OnboardingStatus` model with `hasCompletedTutorial`
- persist new flag in Room and Firestore
- add save use case and repository support
- introduce tutorial view model and overlay composables
- wire tutorial flow to app root

## Testing
- `./gradlew test` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_684464d238dc8329abea56a9a7a20d6f