### PR TITLE
Add tutorial flow fixes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
     implementation(libs.lottie.compose)
     implementation(libs.accompanist.permissions)
     implementation(libs.spinwheel.compose)
+    implementation(libs.tap.target.compose)
 
     /* ── Room (local DB) ────────────────────────────── */
     implementation(libs.room.runtime)

--- a/app/src/main/java/com/app/tibibalance/ui/TibiBalanceRoot.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/TibiBalanceRoot.kt
@@ -11,7 +11,7 @@ import com.app.tibibalance.ui.theme.AppThemeViewModel
 import com.app.tibibalance.ui.theme.TibiBalanceTheme
 import com.app.tibibalance.ui.tutorial.TutorialOverlay
 import com.app.tibibalance.ui.tutorial.TutorialViewModel
-import com.app.tibibalance.ui.tutorial.tutorialTarget
+import com.psoffritti.taptargetcompose.TapTargetCoordinator
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
@@ -22,7 +22,13 @@ fun TibiBalanceRoot() {
     val step   = tutorialVm.currentStep.collectAsState().value
 
     TibiBalanceTheme(mode = mode) {
-        AppNavGraph()
-        TutorialOverlay(step = step, onNext = tutorialVm::proceedToNextStep, onSkip = tutorialVm::skipTutorial)
+        TapTargetCoordinator(showTapTargets = step != null, onComplete = {}) {
+            AppNavGraph()
+            TutorialOverlay(
+                step = step,
+                onNext = tutorialVm::proceedToNextStep,
+                onSkip = tutorialVm::skipTutorial
+            )
+        }
     }
 }

--- a/app/src/main/java/com/app/tibibalance/ui/TibiBalanceRoot.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/TibiBalanceRoot.kt
@@ -9,14 +9,20 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.app.tibibalance.ui.navigation.AppNavGraph
 import com.app.tibibalance.ui.theme.AppThemeViewModel
 import com.app.tibibalance.ui.theme.TibiBalanceTheme
+import com.app.tibibalance.ui.tutorial.TutorialOverlay
+import com.app.tibibalance.ui.tutorial.TutorialViewModel
+import com.app.tibibalance.ui.tutorial.tutorialTarget
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun TibiBalanceRoot() {
     val themeVm: AppThemeViewModel = hiltViewModel()
+    val tutorialVm: TutorialViewModel = hiltViewModel()
     val mode   = themeVm.mode.collectAsState().value
+    val step   = tutorialVm.currentStep.collectAsState().value
 
     TibiBalanceTheme(mode = mode) {
         AppNavGraph()
+        TutorialOverlay(step = step, onNext = tutorialVm::proceedToNextStep, onSkip = tutorialVm::skipTutorial)
     }
 }

--- a/app/src/main/java/com/app/tibibalance/ui/components/buttons/NavBarButton.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/components/buttons/NavBarButton.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.app.tibibalance.ui.components.navigation.BottomNavItem
 import com.app.tibibalance.ui.tutorial.TutorialStepData
+import com.app.tibibalance.ui.navigation.Screen
 
 /**
  * @brief Un [Composable] que renderiza un botón individual para la barra de navegación inferior.
@@ -71,9 +72,11 @@ fun NavBarButton(
     Box(
         modifier = Modifier
             .size(75.dp) // Tamaño fijo para el área del botón
-            .testTag(item.route)
-            .clickable(onClick = onClick)
-            .tutorialTarget(tutorialStep, item.route),
+            .let { base ->
+                val tag = if (item.route == Screen.Habits.route) "habits_tab" else item.route
+                base.testTag(tag).tutorialTarget(tutorialStep, tag)
+            }
+            .clickable(onClick = onClick),
         contentAlignment = Alignment.Center // Centra el contenido (la Columna)
     ) {
         // Fondo de realce, visible solo si 'selected' es true

--- a/app/src/main/java/com/app/tibibalance/ui/components/buttons/NavBarButton.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/components/buttons/NavBarButton.kt
@@ -37,10 +37,12 @@ import androidx.compose.runtime.remember // Para Preview
 import androidx.compose.runtime.setValue // Para Preview
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview // Para Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.app.tibibalance.ui.components.navigation.BottomNavItem
+import com.app.tibibalance.ui.tutorial.TutorialStepData
 
 /**
  * @brief Un [Composable] que renderiza un botón individual para la barra de navegación inferior.
@@ -62,13 +64,16 @@ import com.app.tibibalance.ui.components.navigation.BottomNavItem
 fun NavBarButton(
     item: BottomNavItem,
     selected: Boolean,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    tutorialStep: TutorialStepData? = null
 ) {
     // Contenedor principal del botón, define el tamaño y la acción de clic
     Box(
         modifier = Modifier
             .size(75.dp) // Tamaño fijo para el área del botón
-            .clickable(onClick = onClick), // Hace todo el Box clicable
+            .testTag(item.route)
+            .clickable(onClick = onClick)
+            .tutorialTarget(tutorialStep, item.route),
         contentAlignment = Alignment.Center // Centra el contenido (la Columna)
     ) {
         // Fondo de realce, visible solo si 'selected' es true

--- a/app/src/main/java/com/app/tibibalance/ui/components/containers/ConnectWatchCard.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/components/containers/ConnectWatchCard.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.testTag
 import com.app.tibibalance.R
 
 @Composable
@@ -27,6 +28,7 @@ fun ConnectWatchCard(
             .background(MaterialTheme.colorScheme.surfaceVariant, shape = MaterialTheme.shapes.large)
             .clickable(onClick = onClick)
             .padding(16.dp)
+            .testTag("stats_section")
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Image(

--- a/app/src/main/java/com/app/tibibalance/ui/components/containers/DailyTip.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/components/containers/DailyTip.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -52,7 +53,9 @@ fun DailyTip(
 
         /* Card principal */
         Card(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = modifier
+                .fillMaxWidth()
+                .testTag("daily_tip_card"),
             colors   = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
             shape    = CardDefaults.shape
         ) {

--- a/app/src/main/java/com/app/tibibalance/ui/components/navigation/BottomNavBar.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/components/navigation/BottomNavBar.kt
@@ -44,6 +44,7 @@ import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.runtime.* // Para remember y mutableStateOf en preview
+import com.app.tibibalance.ui.tutorial.TutorialStepData
 
 /**
  * @brief Un [Composable] que renderiza la barra de navegación inferior de la aplicación.
@@ -67,7 +68,8 @@ import androidx.compose.runtime.* // Para remember y mutableStateOf en preview
 fun BottomNavBar(
     items: List<BottomNavItem>,
     selectedRoute: String?,
-    onItemClick: (String) -> Unit
+    onItemClick: (String) -> Unit,
+    tutorialStep: TutorialStepData? = null
 ) {
     Surface(
         modifier = Modifier
@@ -87,7 +89,8 @@ fun BottomNavBar(
                 NavBarButton(
                     item = item,
                     selected = item.route == selectedRoute,
-                    onClick = { onItemClick(item.route) }
+                    onClick = { onItemClick(item.route) },
+                    tutorialStep = tutorialStep
                 )
             }
         }

--- a/app/src/main/java/com/app/tibibalance/ui/components/navigation/BottomNavItem.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/components/navigation/BottomNavItem.kt
@@ -78,4 +78,4 @@ val bottomItems: List<BottomNavItem> = listOf(
         icon  = Icons.Filled.Settings,      // Icono de engranaje
         label = "Ajustes"                   // Etiqueta
     )
-)
+ )

--- a/app/src/main/java/com/app/tibibalance/ui/components/utils/HabitList.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/components/utils/HabitList.kt
@@ -41,6 +41,7 @@ import com.app.tibibalance.ui.components.texts.Description
 import com.app.tibibalance.ui.components.texts.Subtitle
 import com.app.tibibalance.ui.components.texts.Title
 import com.app.tibibalance.ui.screens.habits.HabitUi
+import com.app.tibibalance.ui.tutorial.TutorialStepData
 
 
 /* ────────────────────────────────────────────────────────────────── */
@@ -60,7 +61,8 @@ internal fun HabitList(
     habits : List<HabitUi>,
     onCheck: (HabitUi, Boolean) -> Unit,
     onEdit : (HabitUi) -> Unit,
-    onAdd  : () -> Unit
+    onAdd  : () -> Unit,
+    tutorialStep: TutorialStepData? = null
 ) {
     /** Orden de secciones preferido; lo que no esté aquí va a “Otros”. */
     val sectionOrder = listOf(
@@ -98,6 +100,9 @@ internal fun HabitList(
                 onClick            = onAdd,
                 icon               = Icons.Default.Add,
                 contentDescription = "Agregar hábito",
+                modifier = Modifier
+                    .tutorialTarget(tutorialStep, "habit_fab")
+                    .testTag("habit_fab"),
                 backgroundColor    = MaterialTheme.colorScheme.primary,
                 iconTint           = MaterialTheme.colorScheme.onSurface
             )
@@ -170,7 +175,7 @@ private fun Category(
  * @param onAdd Callback que se invoca al pulsar el botón de añadir.
  */
 @Composable
-internal fun EmptyState(onAdd: () -> Unit) = Column(
+internal fun EmptyState(onAdd: () -> Unit, tutorialStep: TutorialStepData? = null) = Column(
     modifier = Modifier
         .fillMaxSize() // Ocupa todo el espacio disponible
         .padding(32.dp), // Padding generoso
@@ -196,6 +201,9 @@ internal fun EmptyState(onAdd: () -> Unit) = Column(
         onClick            = onAdd, // Callback para iniciar la creación
         icon               = Icons.Default.Add, // Icono de añadir
         contentDescription = "Agregar hábito", // Descripción para accesibilidad
+        modifier = Modifier
+            .tutorialTarget(tutorialStep, "habit_fab")
+            .testTag("habit_fab"),
         backgroundColor    = Color(0xFF3EA8FE), // Color primario personalizado
         iconTint           = Color.White
     )

--- a/app/src/main/java/com/app/tibibalance/ui/screens/emotional/EmotionalCalendarScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/emotional/EmotionalCalendarScreen.kt
@@ -82,7 +82,8 @@ import java.util.Locale
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun EmotionalCalendarScreen(
-    vm: EmotionalCalendarViewModel = hiltViewModel()
+    vm: EmotionalCalendarViewModel = hiltViewModel(),
+    tutorialVm: TutorialViewModel = hiltViewModel()
 ) {
     /* ------------ state ------------- */
     val uiState by vm.ui.collectAsState()
@@ -95,6 +96,12 @@ fun EmotionalCalendarScreen(
             .background(gradient()),
         contentAlignment = Alignment.TopCenter
     ) {
+        androidx.compose.material3.IconButton(
+            onClick = tutorialVm::restartTutorial,
+            modifier = Modifier.align(Alignment.TopEnd)
+        ) {
+            androidx.compose.material3.Icon(Icons.Default.Info, contentDescription = "Ayuda")
+        }
 
         /* ---------- contenido ---------- */
         when (uiState) {

--- a/app/src/main/java/com/app/tibibalance/ui/screens/habits/HabitsScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/habits/HabitsScreen.kt
@@ -88,7 +88,8 @@ import com.app.tibibalance.ui.screens.habits.editHabitWizard.EditHabitModal
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun HabitsScreen(
-    vm: HabitsViewModel = hiltViewModel()
+    vm: HabitsViewModel = hiltViewModel(),
+    tutorialVm: TutorialViewModel = hiltViewModel()
 ) {
     // Estado local para controlar visibilidad del modal de “Agregar hábito”
     var showAdd by remember { mutableStateOf(false) }
@@ -124,6 +125,12 @@ fun HabitsScreen(
             .fillMaxSize()
             .background(gradient())
     ) {
+        androidx.compose.material3.IconButton(
+            onClick = tutorialVm::restartTutorial,
+            modifier = Modifier.align(Alignment.TopEnd)
+        ) {
+            androidx.compose.material3.Icon(Icons.Default.Info, contentDescription = "Ayuda")
+        }
         // Mostrar contenido según el estado actual de la UI
         when (val state = ui) {
             HabitsUiState.Loading -> {
@@ -136,7 +143,10 @@ fun HabitsScreen(
             }
             HabitsUiState.Empty -> {
                 // No hay hábitos: invitación a agregar uno nuevo
-                EmptyState(onAdd = vm::onAddClicked)
+                EmptyState(
+                    onAdd = vm::onAddClicked,
+                    tutorialStep = tutorialVm.currentStep.collectAsState().value
+                )
             }
             is HabitsUiState.Loaded -> {
                 // Mostrar lista de hábitos
@@ -146,7 +156,8 @@ fun HabitsScreen(
                         // TODO: gestionar marcación de hábito completado
                     },
                     onEdit = vm::onHabitClicked,
-                    onAdd = vm::onAddClicked
+                    onAdd = vm::onAddClicked,
+                    tutorialStep = tutorialVm.currentStep.collectAsState().value
                 )
             }
         }

--- a/app/src/main/java/com/app/tibibalance/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/home/HomeScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -20,6 +22,9 @@ import com.app.tibibalance.ui.components.containers.ConnectWatchCard
 import com.app.tibibalance.ui.screens.home.activities.ActivityFeed
 import com.app.tibibalance.ui.components.utils.PagerIndicator
 import com.app.tibibalance.ui.screens.home.activities.ActivityLogDialog
+import com.app.tibibalance.ui.tutorial.TutorialViewModel
+import com.app.tibibalance.ui.tutorial.tutorialTarget
+import com.app.tibibalance.ui.tutorial.TutorialStepData
 
 private const val PAGES = 2     // Tip · Métricas
 
@@ -27,7 +32,8 @@ private const val PAGES = 2     // Tip · Métricas
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun HomeScreen(
-    viewModel: HomeViewModel = hiltViewModel()
+    viewModel: HomeViewModel = hiltViewModel(),
+    tutorialVm: TutorialViewModel = hiltViewModel()
 ) {
     val state      by viewModel.ui.collectAsState()
     val pagerState = rememberPagerState(initialPage = 0, pageCount = { 2 })
@@ -39,6 +45,9 @@ fun HomeScreen(
             .padding(top = 8.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
+        androidx.compose.material3.IconButton(onClick = tutorialVm::restartTutorial) {
+            androidx.compose.material3.Icon(Icons.Default.Info, contentDescription = "Ayuda")
+        }
         /* Saludo */
         Title("¡Hola de nuevo! ${state.user?.displayName.orEmpty()}")
 
@@ -51,7 +60,7 @@ fun HomeScreen(
                 .fillMaxWidth()
         ) { page ->
             when (page) {
-                0 -> TipPage(state.dailyTip)
+                0 -> TipPage(state.dailyTip, tutorialVm.currentStep.collectAsState().value)
                 1 -> MetricsPage()
             }
         }
@@ -88,10 +97,11 @@ fun HomeScreen(
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 private fun TipPage(
-    tip: DailyTip?
+    tip: DailyTip?,
+    step: TutorialStepData?
 ) {
     if (tip != null) {
-        DailyTip(tip = tip)
+        DailyTip(tip = tip, modifier = Modifier.tutorialTarget(step, "daily_tip_card"))
     } else {
         // Fallback cuando no hay tip disponible (raro)
         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.TopStart) {

--- a/app/src/main/java/com/app/tibibalance/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/home/HomeScreen.kt
@@ -61,7 +61,7 @@ fun HomeScreen(
         ) { page ->
             when (page) {
                 0 -> TipPage(state.dailyTip, tutorialVm.currentStep.collectAsState().value)
-                1 -> MetricsPage()
+                1 -> MetricsPage(tutorialVm.currentStep.collectAsState().value)
             }
         }
 
@@ -112,7 +112,7 @@ private fun TipPage(
 
 /* -------------- Página 1: Métricas ------------------- */
 @Composable
-private fun MetricsPage() {
+private fun MetricsPage(step: TutorialStepData?) {
     Column(
         Modifier
             .fillMaxSize()
@@ -125,7 +125,8 @@ private fun MetricsPage() {
            ⚠️ Aún NO depende de isWatchConnected; se mostrará siempre.
            Cuando implementes la lógica, ocúltalo cuando `watchConnected == true`. */
         ConnectWatchCard(
-            onClick = { /* TODO: navegar a flujo de enlace */ }
+            onClick = { /* TODO: navegar a flujo de enlace */ },
+            modifier = Modifier.tutorialTarget(step, "stats_section")
         )
     }
 }

--- a/app/src/main/java/com/app/tibibalance/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/main/MainScreen.kt
@@ -19,6 +19,8 @@ import com.app.tibibalance.ui.screens.habits.HabitsScreen
 import com.app.tibibalance.ui.screens.home.HomeScreen
 import com.app.tibibalance.ui.screens.profile.show.ViewProfileScreen
 import com.app.tibibalance.ui.screens.settings.SettingsScreen
+import com.app.tibibalance.ui.tutorial.TutorialViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
@@ -30,6 +32,8 @@ fun MainScreen(rootNav: NavHostController) {
     val current = mainNav.currentBackStackEntryAsState()
     val currentRoute = current.value?.destination?.route
 
+    val tutorialVm: TutorialViewModel = hiltViewModel()
+
     Scaffold(
         bottomBar = {
             BottomNavBar(
@@ -40,7 +44,8 @@ fun MainScreen(rootNav: NavHostController) {
                     if (route != currentRoute) {
                         mainNav.navigate(route) { launchSingleTop = true }
                     }
-                }
+                },
+                tutorialStep = tutorialVm.currentStep.collectAsState().value
             )
         }
     ) { padding ->

--- a/app/src/main/java/com/app/tibibalance/ui/screens/profile/show/ViewProfileScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/profile/show/ViewProfileScreen.kt
@@ -28,6 +28,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import coil3.compose.AsyncImage
 import com.app.tibibalance.R
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
 import com.app.tibibalance.ui.components.buttons.SecondaryButton
 import com.app.tibibalance.ui.components.containers.FormContainer
 import com.app.tibibalance.ui.components.containers.ImageContainer
@@ -46,7 +48,8 @@ import java.time.format.DateTimeFormatter
 @Composable
 fun ViewProfileScreen(
     navController: NavHostController,
-    vm: ViewProfileViewModel = hiltViewModel()
+    vm: ViewProfileViewModel = hiltViewModel(),
+    tutorialVm: TutorialViewModel = hiltViewModel()
 ) {
     val ui by vm.ui.collectAsState()
 
@@ -55,6 +58,12 @@ fun ViewProfileScreen(
             .fillMaxSize()
             .background(gradient())
     ) {
+        androidx.compose.material3.IconButton(
+            onClick = tutorialVm::restartTutorial,
+            modifier = Modifier.align(Alignment.TopEnd)
+        ) {
+            androidx.compose.material3.Icon(Icons.Default.Info, contentDescription = "Ayuda")
+        }
         when {
             ui.loading -> Centered("Cargando…")
 

--- a/app/src/main/java/com/app/tibibalance/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/settings/SettingsScreen.kt
@@ -61,7 +61,8 @@ import com.app.tibibalance.ui.components.utils.gradient
 
 @Composable
 fun SettingsScreen(
-    navController: NavHostController
+    navController: NavHostController,
+    tutorialVm: TutorialViewModel = hiltViewModel()
 ) {
     val vm: SettingsViewModel = hiltViewModel()
     val ui by vm.ui.collectAsState()
@@ -126,6 +127,12 @@ private fun SettingsContent(
             .fillMaxSize()
             .background(gradient())
     ) {
+        androidx.compose.material3.IconButton(
+            onClick = tutorialVm::restartTutorial,
+            modifier = Modifier.align(Alignment.TopEnd)
+        ) {
+            androidx.compose.material3.Icon(Icons.Default.Info, contentDescription = "Ayuda")
+        }
 
         SettingsBody(
             ui                   = ui,

--- a/app/src/main/java/com/app/tibibalance/ui/tutorial/TutorialOverlay.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/tutorial/TutorialOverlay.kt
@@ -1,0 +1,53 @@
+package com.app.tibibalance.ui.tutorial
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.psoffritti.taptargetcompose.TapTargetCoordinator
+import com.psoffritti.taptargetcompose.tapTarget
+import com.psoffritti.taptargetcompose.TapTargetDefinition
+import com.psoffritti.taptargetcompose.TextDefinition
+import com.psoffritti.taptargetcompose.TapTargetStyle
+
+@Composable
+fun TutorialOverlay(
+    step: TutorialStepData?,
+    onNext: () -> Unit,
+    onSkip: () -> Unit
+) {
+    if (step == null) return
+
+    TapTargetCoordinator(showTapTargets = true, onComplete = {}) {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.BottomCenter) {
+            androidx.compose.foundation.layout.Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.align(Alignment.BottomCenter)
+            ) {
+                Text(step.title)
+                Text(step.message)
+                androidx.compose.foundation.layout.Row {
+                    Button(onClick = onNext) { Text("Siguiente") }
+                    Button(onClick = onSkip) { Text("Omitir") }
+                }
+            }
+        }
+    }
+}
+
+fun Modifier.tutorialTarget(current: TutorialStepData?, id: String): Modifier {
+    return if (current != null && current.targetId == id) {
+        this.testTag(id).tapTarget(
+            TapTargetDefinition(
+                precedence = 0,
+                title = TextDefinition(current.title),
+                description = TextDefinition(current.message),
+                tapTargetStyle = TapTargetStyle()
+            )
+        )
+    } else this
+}

--- a/app/src/main/java/com/app/tibibalance/ui/tutorial/TutorialOverlay.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/tutorial/TutorialOverlay.kt
@@ -1,14 +1,17 @@
 package com.app.tibibalance.ui.tutorial
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import com.psoffritti.taptargetcompose.TapTargetCoordinator
+import androidx.compose.ui.text.font.FontWeight
 import com.psoffritti.taptargetcompose.tapTarget
 import com.psoffritti.taptargetcompose.TapTargetDefinition
 import com.psoffritti.taptargetcompose.TextDefinition
@@ -22,18 +25,16 @@ fun TutorialOverlay(
 ) {
     if (step == null) return
 
-    TapTargetCoordinator(showTapTargets = true, onComplete = {}) {
-        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.BottomCenter) {
-            androidx.compose.foundation.layout.Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier.align(Alignment.BottomCenter)
-            ) {
-                Text(step.title)
-                Text(step.message)
-                androidx.compose.foundation.layout.Row {
-                    Button(onClick = onNext) { Text("Siguiente") }
-                    Button(onClick = onSkip) { Text("Omitir") }
-                }
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.BottomCenter) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.align(Alignment.BottomCenter)
+        ) {
+            Text(step.title, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+            Text(step.message, style = MaterialTheme.typography.bodyMedium)
+            Row {
+                Button(onClick = onNext) { Text("Siguiente") }
+                Button(onClick = onSkip) { Text("Omitir") }
             }
         }
     }

--- a/app/src/main/java/com/app/tibibalance/ui/tutorial/TutorialStep.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/tutorial/TutorialStep.kt
@@ -1,0 +1,122 @@
+package com.app.tibibalance.ui.tutorial
+
+sealed class TutorialStep(val data: TutorialStepData) {
+    data object Intro : TutorialStep(
+        TutorialStepData(
+            id = "intro",
+            title = "¡Bienvenido a TibiBalance!",
+            message = "Conoce lo básico para empezar",
+            targetId = null
+        )
+    )
+
+    data object HabitsTab : TutorialStep(
+        TutorialStepData(
+            id = "habits_tab",
+            title = "Empieza a Crear Hábitos",
+            message = "Aquí gestionarás todos tus hábitos",
+            targetId = "habits_tab"
+        )
+    )
+
+    data object CreateHabit : TutorialStep(
+        TutorialStepData(
+            id = "create_habit",
+            title = "Crea Tu Primer Hábito",
+            message = "Toca aquí para añadir un nuevo hábito",
+            targetId = "habit_fab"
+        )
+    )
+
+    data object DailyProgress : TutorialStep(
+        TutorialStepData(
+            id = "daily_progress",
+            title = "Tu Progreso Diario",
+            message = "Aquí verás un resumen de tu progreso diario",
+            targetId = "daily_progress_card"
+        )
+    )
+
+    data object ActivityFab : TutorialStep(
+        TutorialStepData(
+            id = "activity_fab",
+            title = "Registra tus Actividades",
+            message = "Toca este botón para registrar una actividad completada",
+            targetId = "activity_fab"
+        )
+    )
+
+    data object DailyTip : TutorialStep(
+        TutorialStepData(
+            id = "daily_tip",
+            title = "Consejos Diarios",
+            message = "Obtén un consejo diario para mantener tu motivación",
+            targetId = "daily_tip_card"
+        )
+    )
+
+    data object Stats : TutorialStep(
+        TutorialStepData(
+            id = "stats_section",
+            title = "Analiza tu Progreso",
+            message = "Explora tus estadísticas y visualiza tu progreso",
+            targetId = "stats_section"
+        )
+    )
+
+    data object Profile : TutorialStep(
+        TutorialStepData(
+            id = "profile_section",
+            title = "Accede a tu Perfil",
+            message = "En tu perfil, puedes editar tu información",
+            targetId = "profile_section"
+        )
+    )
+
+    data object Settings : TutorialStep(
+        TutorialStepData(
+            id = "settings_section",
+            title = "Ajustes Generales",
+            message = "Personaliza la aplicación a tu gusto",
+            targetId = "settings_section"
+        )
+    )
+
+    data object Final : TutorialStep(
+        TutorialStepData(
+            id = "final",
+            title = "¡Eso es todo por ahora!",
+            message = "Disfruta usando TibiBalance",
+            targetId = null
+        )
+    )
+
+    companion object {
+        /**
+         * Returns the ordered list of steps for the tutorial.
+         *
+         * @param hasChallenge lambda that returns true when the user has at least
+         * one habit in challenge mode. Used to conditionally show certain steps.
+         */
+        fun all(hasChallenge: suspend () -> Boolean): List<TutorialStepData> = listOf(
+            Intro.data,
+            HabitsTab.data,
+            CreateHabit.data,
+            DailyProgress.data.copy(conditionalCheck = hasChallenge),
+            ActivityFab.data.copy(conditionalCheck = hasChallenge),
+            DailyTip.data,
+            Stats.data,
+            Profile.data,
+            Settings.data,
+            Final.data
+        )
+    }
+}
+
+data class TutorialStepData(
+    val id: String,
+    val title: String,
+    val message: String,
+    val targetId: String?,
+    val conditionalCheck: (suspend () -> Boolean)? = null
+)

--- a/app/src/main/java/com/app/tibibalance/ui/tutorial/TutorialViewModel.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/tutorial/TutorialViewModel.kt
@@ -1,0 +1,74 @@
+package com.app.tibibalance.ui.tutorial
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.app.domain.repository.AuthRepository
+import com.app.domain.repository.HabitRepository
+import com.app.domain.usecase.onboarding.ObserveOnboardingStatus
+import com.app.domain.usecase.tutorial.SaveTutorialStatusUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class TutorialViewModel @Inject constructor(
+    private val authRepo: AuthRepository,
+    private val observeStatus: ObserveOnboardingStatus,
+    private val saveStatus: SaveTutorialStatusUseCase,
+    private val habitRepo: HabitRepository
+) : ViewModel() {
+
+    private val _currentStep = MutableStateFlow<TutorialStepData?>(null)
+    val currentStep: StateFlow<TutorialStepData?> = _currentStep
+
+    private val steps = TutorialStep.all(::hasChallengeHabit)
+    private var index = -1
+
+    init { startIfNeeded() }
+
+    private fun startIfNeeded() {
+        viewModelScope.launch {
+            val uid = authRepo.authState().first() ?: return@launch
+            val status = observeStatus(uid).first()
+            if (status.tutorialCompleted && !status.hasCompletedTutorial) {
+                proceedToNextStep()
+            }
+        }
+    }
+
+    fun proceedToNextStep() {
+        viewModelScope.launch {
+            do {
+                index++
+                if (index >= steps.size) { finishTutorial(); return@launch }
+                val step = steps[index]
+                val show = step.conditionalCheck?.invoke() ?: true
+            } while (!show)
+            _currentStep.value = steps[index]
+        }
+    }
+
+    fun skipTutorial() {
+        viewModelScope.launch {
+            finishTutorial()
+        }
+    }
+
+    fun restartTutorial() {
+        index = -1
+        proceedToNextStep()
+    }
+
+    private suspend fun hasChallengeHabit(): Boolean {
+        return habitRepo.observeUserHabits().first().any { it.challenge != null }
+    }
+
+    private suspend fun finishTutorial() {
+        _currentStep.value = null
+        val uid = authRepo.authState().first() ?: return
+        saveStatus(uid, true)
+    }
+}

--- a/data/src/main/java/com/app/data/local/db/AppDb.kt
+++ b/data/src/main/java/com/app/data/local/db/AppDb.kt
@@ -29,7 +29,7 @@ import com.app.data.local.entities.UserEntity
         DailyMetricsEntity::class, OnboardingStatusEntity::class,
         DailyTipEntity::class
     ],
-    version = 2,
+    version = 4,
     exportSchema = true
 )
 @TypeConverters(

--- a/data/src/main/java/com/app/data/local/db/Migrations.kt
+++ b/data/src/main/java/com/app/data/local/db/Migrations.kt
@@ -18,3 +18,10 @@ val MIGRATION_2_3 = object : Migration(2, 3) {
         db.execSQL("""CREATE INDEX IF NOT EXISTS index_activities_timestamp ON activities(timestamp)""")
     }
 }
+
+/** v3 → v4 · nueva columna hasCompletedTutorial */
+val MIGRATION_3_4 = object : Migration(3, 4) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE onboarding_status ADD COLUMN hasCompletedTutorial INTEGER NOT NULL DEFAULT 0")
+    }
+}

--- a/data/src/main/java/com/app/data/local/di/DatabaseModule.kt
+++ b/data/src/main/java/com/app/data/local/di/DatabaseModule.kt
@@ -33,7 +33,7 @@ object DatabaseModule {
     ): AppDb =
         Room.databaseBuilder(ctx, AppDb::class.java, "tibi.db")
             .openHelperFactory(factory)
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3)       // 👈 sustituye fallbackToDestructive
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)       // 👈 sustituye fallbackToDestructive
             .build()
 
 

--- a/data/src/main/java/com/app/data/local/entities/OnboardingStatusEntity.kt
+++ b/data/src/main/java/com/app/data/local/entities/OnboardingStatusEntity.kt
@@ -15,6 +15,7 @@ data class OnboardingStatusEntity(
     val tutorialCompleted            : Boolean,
     val legalAccepted                : Boolean,
     val permissionsAsked             : Boolean,
+    val hasCompletedTutorial         : Boolean,
     val completedAt                  : Instant?,
     @Embedded(prefix = "m_")      val meta: SyncMeta
 )

--- a/data/src/main/java/com/app/data/mappers/OnboardingMapper.kt
+++ b/data/src/main/java/com/app/data/mappers/OnboardingMapper.kt
@@ -15,6 +15,7 @@ object OnboardingMappers {
         tutorialCompleted = tutorialCompleted,
         legalAccepted     = legalAccepted,
         permissionsAsked  = permissionsAsked,
+        hasCompletedTutorial = hasCompletedTutorial,
         completedAt       = completedAt,
         meta              = meta
     )
@@ -26,6 +27,7 @@ object OnboardingMappers {
             tutorialCompleted = tutorialCompleted,
             legalAccepted     = legalAccepted,
             permissionsAsked  = permissionsAsked,
+            hasCompletedTutorial = hasCompletedTutorial,
             completedAt       = completedAt,
             meta              = meta
         )

--- a/data/src/main/java/com/app/data/remote/firebase/OnboardingFirestoreService.kt
+++ b/data/src/main/java/com/app/data/remote/firebase/OnboardingFirestoreService.kt
@@ -33,6 +33,7 @@ class OnboardingFirestoreService @Inject constructor(
             tutorialCompleted = snap.getBoolean("tutorialCompleted") ?: false,
             legalAccepted     = snap.getBoolean("legalAccepted") ?: false,
             permissionsAsked  = snap.getBoolean("permissionsAsked") ?: false,
+            hasCompletedTutorial = snap.getBoolean("hasCompletedTutorial") ?: false,
             completedAt       = snap.getString("completedAt")?.let(Instant::parse),
             meta = SyncMeta(
                 updatedAt   = snap.getString("updatedAt")?.let(Instant::parse)

--- a/domain/src/main/java/com/app/domain/entities/OnboardingStatus.kt
+++ b/domain/src/main/java/com/app/domain/entities/OnboardingStatus.kt
@@ -14,6 +14,7 @@ data class OnboardingStatus(
     val tutorialCompleted : Boolean = false,
     val legalAccepted     : Boolean = false,
     val permissionsAsked  : Boolean = false,
+    val hasCompletedTutorial: Boolean = false,
     val completedAt       : Instant? = null,
     val meta              : SyncMeta = SyncMeta()
 )

--- a/domain/src/main/java/com/app/domain/repository/OnboardingRepository.kt
+++ b/domain/src/main/java/com/app/domain/repository/OnboardingRepository.kt
@@ -23,5 +23,6 @@ interface OnboardingRepository {
      * Debe disparar la sincronización remota en la capa de datos.
      */
     suspend fun save(uid: String, status: OnboardingStatus)
+    suspend fun saveTutorialStatus(uid: String, completed: Boolean)
     suspend fun syncNow(uid: String): Result<Unit>
 }

--- a/domain/src/main/java/com/app/domain/usecase/tutorial/SaveTutorialStatusUseCase.kt
+++ b/domain/src/main/java/com/app/domain/usecase/tutorial/SaveTutorialStatusUseCase.kt
@@ -1,0 +1,12 @@
+package com.app.domain.usecase.tutorial
+
+import com.app.domain.repository.OnboardingRepository
+import javax.inject.Inject
+
+class SaveTutorialStatusUseCase @Inject constructor(
+    private val repo: OnboardingRepository
+) {
+    suspend operator fun invoke(uid: String, completed: Boolean) {
+        repo.saveTutorialStatus(uid, completed)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ coil                  = "3.2.0"
 lottie                = "6.6.6"
 accompanist           = "0.37.3"
 spinwheel             = "1.1.1"
+tap-target-compose    = "1.2.1"
 playServicesWearable  = "19.0.0"
 healthServices        = "1.0.0"
 wearCompose           = "1.4.1"
@@ -92,6 +93,7 @@ coil-network-okhttp      = { group = "io.coil-kt.coil3",           name = "coil-
 lottie-compose           = { group = "com.airbnb.android",         name = "lottie-compose",            version.ref = "lottie" }
 accompanist-permissions  = { group = "com.google.accompanist",     name = "accompanist-permissions",   version.ref = "accompanist" }
 spinwheel-compose        = { group = "com.github.commandiron",     name = "SpinWheelCompose",          version.ref = "spinwheel" }
+tap-target-compose       = { group = "com.pierfrancescosoffritti.taptargetcompose", name = "core", version.ref = "tap-target-compose" }
 
 room-runtime             = { group = "androidx.room",             name = "room-runtime",              version.ref = "room" }
 room-ktx                 = { group = "androidx.room",             name = "room-ktx",                  version.ref = "room" }


### PR DESCRIPTION
## Summary
- refine list of tutorial steps with conditional check hooks
- expose help button on profile screen
- include new restart logic via `TutorialViewModel`
- fix missing newline in `OnboardingStatusEntity`

## Testing
- `./gradlew test --no-daemon` *(fails: Cannot find a Java installation matching requirements)*

------
https://chatgpt.com/codex/tasks/task_e_684464d238dc8329abea56a9a7a20d6f