### PR TITLE
Implement tutorial framework

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
     implementation(libs.lottie.compose)
     implementation(libs.accompanist.permissions)
     implementation(libs.spinwheel.compose)
+    implementation(libs.tap.target.compose)
 
     /* ── Room (local DB) ────────────────────────────── */
     implementation(libs.room.runtime)

--- a/app/src/main/java/com/app/tibibalance/tutorial/TutorialOverlay.kt
+++ b/app/src/main/java/com/app/tibibalance/tutorial/TutorialOverlay.kt
@@ -1,0 +1,36 @@
+package com.app.tibibalance.tutorial
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import com.psoffritti.taptargetcompose.TapTargetCoordinator
+import com.psoffritti.taptargetcompose.TapTargetDefinition
+import com.psoffritti.taptargetcompose.TextDefinition
+import com.psoffritti.taptargetcompose.tapTarget
+
+/**
+ * Overlay composable displaying the current tutorial step using TapTargetCompose.
+ */
+@Composable
+fun TutorialOverlay(viewModel: TutorialViewModel, content: @Composable () -> Unit) {
+    val step by viewModel.currentStep.collectAsState()
+
+    val show = step != null
+
+    TapTargetCoordinator(showTapTargets = show, onComplete = { viewModel.proceedToNextStep() }) {
+        content()
+        step?.let { s ->
+            val definition = TapTargetDefinition(
+                title = TextDefinition(s.title),
+                description = TextDefinition(s.message),
+                precedence = 0
+            )
+            Button(onClick = { viewModel.proceedToNextStep() }, modifier = Modifier.tapTarget(definition)) {
+                Text(" ")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/app/tibibalance/tutorial/TutorialStep.kt
+++ b/app/src/main/java/com/app/tibibalance/tutorial/TutorialStep.kt
@@ -1,0 +1,12 @@
+package com.app.tibibalance.tutorial
+
+/**
+ * Data that defines a single tutorial step.
+ */
+data class TutorialStepData(
+    val id: String,
+    val title: String,
+    val message: String,
+    val targetId: String?,
+    val conditionalCheck: (suspend () -> Boolean)? = null
+)

--- a/app/src/main/java/com/app/tibibalance/tutorial/TutorialSteps.kt
+++ b/app/src/main/java/com/app/tibibalance/tutorial/TutorialSteps.kt
@@ -1,0 +1,69 @@
+package com.app.tibibalance.tutorial
+
+/**
+ * Provides the list of tutorial steps shown to the user.
+ */
+object TutorialSteps {
+    val all = listOf(
+        TutorialStepData(
+            id = "intro",
+            title = "Bienvenido",
+            message = "This tutorial will guide you through the app.",
+            targetId = null
+        ),
+        TutorialStepData(
+            id = "habits_tab",
+            title = "Empieza a crear hábitos",
+            message = "Open the Habits section from here.",
+            targetId = "habits_tab"
+        ),
+        TutorialStepData(
+            id = "habit_fab",
+            title = "Crea tu primer hábito",
+            message = "Tap the plus button to add a habit.",
+            targetId = "habit_fab"
+        ),
+        TutorialStepData(
+            id = "daily_progress",
+            title = "Tu progreso diario",
+            message = "Check your daily progress here.",
+            targetId = "daily_progress_card"
+        ),
+        TutorialStepData(
+            id = "activity_fab",
+            title = "Registra actividades",
+            message = "Log your habit activities.",
+            targetId = "activity_fab"
+        ),
+        TutorialStepData(
+            id = "daily_tip",
+            title = "Consejo diario",
+            message = "Read helpful tips every day.",
+            targetId = "daily_tip_card"
+        ),
+        TutorialStepData(
+            id = "stats",
+            title = "Analiza tu progreso",
+            message = "Connect your watch and view stats.",
+            targetId = "connect_watch_card"
+        ),
+        TutorialStepData(
+            id = "profile",
+            title = "Accede a tu perfil",
+            message = "Manage your achievements here.",
+            targetId = "profile_section"
+        ),
+        TutorialStepData(
+            id = "settings",
+            title = "Ajustes generales",
+            message = "Configure the app to your liking.",
+            targetId = "settings_section"
+        ),
+        TutorialStepData(
+            id = "final",
+            title = "Listo",
+            message = "Tutorial completed!",
+            targetId = null
+        )
+    )
+}

--- a/app/src/main/java/com/app/tibibalance/tutorial/TutorialViewModel.kt
+++ b/app/src/main/java/com/app/tibibalance/tutorial/TutorialViewModel.kt
@@ -1,0 +1,64 @@
+package com.app.tibibalance.tutorial
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.app.domain.auth.AuthUidProvider
+import com.app.domain.repository.HabitRepository
+import com.app.domain.usecase.onboarding.ObserveOnboardingStatus
+import com.app.domain.usecase.tutorial.SaveTutorialStatusUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+/** ViewModel that controls the tutorial flow. */
+@HiltViewModel
+class TutorialViewModel @Inject constructor(
+    private val observeStatus: ObserveOnboardingStatus,
+    private val saveTutorialStatus: SaveTutorialStatusUseCase,
+    private val habitRepo: HabitRepository,
+    private val uidProvider: AuthUidProvider
+) : ViewModel() {
+
+    private val steps = TutorialSteps.all
+    private var index = 0
+
+    private val _current = MutableStateFlow<TutorialStepData?>(null)
+    val currentStep: StateFlow<TutorialStepData?> = _current
+
+    init { viewModelScope.launch { startIfNeeded() } }
+
+    private suspend fun startIfNeeded() {
+        val uid = uidProvider()
+        val status = observeStatus(uid).first()
+        if (status.tutorialCompleted && !status.hasCompletedTutorial) {
+            _current.value = steps.first()
+        }
+    }
+
+    fun proceedToNextStep() {
+        index++
+        if (index >= steps.size) {
+            finishTutorial()
+        } else {
+            _current.value = steps[index]
+        }
+    }
+
+    fun skipTutorial() { finishTutorial() }
+
+    fun restartTutorial() {
+        index = 0
+        _current.value = steps.first()
+    }
+
+    private fun finishTutorial() {
+        viewModelScope.launch {
+            val uid = uidProvider()
+            saveTutorialStatus(uid, true)
+            _current.value = null
+        }
+    }
+}

--- a/app/src/main/java/com/app/tibibalance/ui/TibiBalanceRoot.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/TibiBalanceRoot.kt
@@ -9,14 +9,19 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.app.tibibalance.ui.navigation.AppNavGraph
 import com.app.tibibalance.ui.theme.AppThemeViewModel
 import com.app.tibibalance.ui.theme.TibiBalanceTheme
+import com.app.tibibalance.tutorial.TutorialOverlay
+import com.app.tibibalance.tutorial.TutorialViewModel
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun TibiBalanceRoot() {
     val themeVm: AppThemeViewModel = hiltViewModel()
+    val tutorialVm: TutorialViewModel = hiltViewModel()
     val mode   = themeVm.mode.collectAsState().value
 
     TibiBalanceTheme(mode = mode) {
-        AppNavGraph()
+        TutorialOverlay(viewModel = tutorialVm) {
+            AppNavGraph()
+        }
     }
 }

--- a/app/src/main/java/com/app/tibibalance/ui/components/buttons/NavBarButton.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/components/buttons/NavBarButton.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.tooling.preview.Preview // Para Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.app.tibibalance.ui.components.navigation.BottomNavItem
+import androidx.compose.ui.platform.testTag
 
 /**
  * @brief Un [Composable] que renderiza un botón individual para la barra de navegación inferior.
@@ -67,8 +68,13 @@ fun NavBarButton(
     // Contenedor principal del botón, define el tamaño y la acción de clic
     Box(
         modifier = Modifier
-            .size(75.dp) // Tamaño fijo para el área del botón
-            .clickable(onClick = onClick), // Hace todo el Box clicable
+            .size(75.dp)
+            .clickable(onClick = onClick)
+            .then(
+                if (item.route == com.app.tibibalance.ui.navigation.Screen.Habits.route) {
+                    Modifier.testTag("habits_tab")
+                } else Modifier
+            ),
         contentAlignment = Alignment.Center // Centra el contenido (la Columna)
     ) {
         // Fondo de realce, visible solo si 'selected' es true

--- a/app/src/main/java/com/app/tibibalance/ui/components/containers/ConnectWatchCard.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/components/containers/ConnectWatchCard.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.testTag
 import com.app.tibibalance.R
 
 @Composable
@@ -26,6 +27,7 @@ fun ConnectWatchCard(
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.surfaceVariant, shape = MaterialTheme.shapes.large)
             .clickable(onClick = onClick)
+            .testTag("connect_watch_card")
             .padding(16.dp)
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {

--- a/app/src/main/java/com/app/tibibalance/ui/components/containers/DailyTip.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/components/containers/DailyTip.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.platform.testTag
 import com.app.domain.entities.Challenge
 import com.app.domain.entities.DailyTip
 import com.app.domain.entities.DailyTipItem
@@ -52,7 +53,9 @@ fun DailyTip(
 
         /* Card principal */
         Card(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("daily_tip_card"),
             colors   = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
             shape    = CardDefaults.shape
         ) {

--- a/app/src/main/java/com/app/tibibalance/ui/components/utils/HabitList.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/components/utils/HabitList.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.platform.testTag
 import com.app.domain.enums.HabitCategory
 import com.app.tibibalance.ui.components.buttons.RoundedIconButton
 import com.app.tibibalance.ui.components.containers.IconContainer
@@ -99,7 +100,8 @@ internal fun HabitList(
                 icon               = Icons.Default.Add,
                 contentDescription = "Agregar hábito",
                 backgroundColor    = MaterialTheme.colorScheme.primary,
-                iconTint           = MaterialTheme.colorScheme.onSurface
+                iconTint           = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.testTag("habit_fab")
             )
         }
     }

--- a/app/src/main/java/com/app/tibibalance/ui/screens/emotional/EmotionalCalendarScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/emotional/EmotionalCalendarScreen.kt
@@ -30,9 +30,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Help
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -84,6 +87,7 @@ import java.util.Locale
 fun EmotionalCalendarScreen(
     vm: EmotionalCalendarViewModel = hiltViewModel()
 ) {
+    val tutorialVm: com.app.tibibalance.tutorial.TutorialViewModel = hiltViewModel()
     /* ------------ state ------------- */
     val uiState by vm.ui.collectAsState()
     val dialog by vm.dialog.collectAsState()
@@ -95,6 +99,9 @@ fun EmotionalCalendarScreen(
             .background(gradient()),
         contentAlignment = Alignment.TopCenter
     ) {
+        androidx.compose.material3.IconButton(onClick = { tutorialVm.restartTutorial() }, modifier = Modifier.align(Alignment.TopEnd)) {
+            androidx.compose.material3.Icon(Icons.Default.Help, contentDescription = "Ayuda")
+        }
 
         /* ---------- contenido ---------- */
         when (uiState) {

--- a/app/src/main/java/com/app/tibibalance/ui/screens/habits/HabitsScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/habits/HabitsScreen.kt
@@ -38,8 +38,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Whatshot
+import androidx.compose.material.icons.filled.Help
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -90,6 +92,7 @@ import com.app.tibibalance.ui.screens.habits.editHabitWizard.EditHabitModal
 fun HabitsScreen(
     vm: HabitsViewModel = hiltViewModel()
 ) {
+    val tutorialVm: com.app.tibibalance.tutorial.TutorialViewModel = hiltViewModel()
     // Estado local para controlar visibilidad del modal de “Agregar hábito”
     var showAdd by remember { mutableStateOf(false) }
 
@@ -124,6 +127,9 @@ fun HabitsScreen(
             .fillMaxSize()
             .background(gradient())
     ) {
+        androidx.compose.material3.IconButton(onClick = { tutorialVm.restartTutorial() }, modifier = Modifier.align(Alignment.TopEnd)) {
+            androidx.compose.material3.Icon(Icons.Default.Help, contentDescription = "Ayuda")
+        }
         // Mostrar contenido según el estado actual de la UI
         when (val state = ui) {
             HabitsUiState.Loading -> {

--- a/app/src/main/java/com/app/tibibalance/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/home/HomeScreen.kt
@@ -8,6 +8,9 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.IconButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Help
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -29,6 +32,7 @@ private const val PAGES = 2     // Tip · Métricas
 fun HomeScreen(
     viewModel: HomeViewModel = hiltViewModel()
 ) {
+    val tutorialVm: com.app.tibibalance.tutorial.TutorialViewModel = hiltViewModel()
     val state      by viewModel.ui.collectAsState()
     val pagerState = rememberPagerState(initialPage = 0, pageCount = { 2 })
 
@@ -39,6 +43,12 @@ fun HomeScreen(
             .padding(top = 8.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
+        androidx.compose.material3.IconButton(onClick = { tutorialVm.restartTutorial() }, modifier = Modifier.align(Alignment.End)) {
+            androidx.compose.material3.Icon(
+                imageVector = Icons.Default.Help,
+                contentDescription = "Ayuda"
+            )
+        }
         /* Saludo */
         Title("¡Hola de nuevo! ${state.user?.displayName.orEmpty()}")
 

--- a/app/src/main/java/com/app/tibibalance/ui/screens/profile/show/ViewProfileScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/profile/show/ViewProfileScreen.kt
@@ -33,6 +33,7 @@ import com.app.tibibalance.ui.components.containers.FormContainer
 import com.app.tibibalance.ui.components.containers.ImageContainer
 import com.app.tibibalance.ui.components.containers.ProfileContainer
 import com.app.tibibalance.ui.components.buttons.AchievementAccessItem
+import androidx.compose.ui.platform.testTag
 
 import com.app.tibibalance.ui.components.inputs.InputText
 import com.app.tibibalance.ui.components.texts.Description
@@ -82,7 +83,8 @@ private fun ProfileContent(
         modifier = Modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
-            .padding(horizontal = 16.dp, vertical = 24.dp),
+            .padding(horizontal = 16.dp, vertical = 24.dp)
+            .testTag("profile_section"),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Spacer(Modifier.height(10.dp))

--- a/app/src/main/java/com/app/tibibalance/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/app/tibibalance/ui/screens/settings/SettingsScreen.kt
@@ -44,6 +44,11 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.app.domain.entities.User
 import com.app.domain.enums.ThemeMode
+import androidx.compose.ui.platform.testTag
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Help
 import com.app.tibibalance.R
 import com.app.tibibalance.ui.components.buttons.DangerButton
 import com.app.tibibalance.ui.components.buttons.SwitchToggle
@@ -115,6 +120,7 @@ private fun SettingsContent(
     vm: SettingsViewModel,
     ui: SettingsViewModel.UiState
 ) {
+    val tutorialVm: com.app.tibibalance.tutorial.TutorialViewModel = hiltViewModel()
     /* Destinos secundarios */
     val onEditPersonal   = { navController.navigate(Screen.EditProfile.route) }
     val onConfigureNotis = { navController.navigate(Screen.ConfigureNotif.route) }
@@ -126,6 +132,9 @@ private fun SettingsContent(
             .fillMaxSize()
             .background(gradient())
     ) {
+        androidx.compose.material3.IconButton(onClick = { tutorialVm.restartTutorial() }, modifier = Modifier.align(Alignment.TopEnd)) {
+            androidx.compose.material3.Icon(Icons.Default.Help, contentDescription = "Ayuda")
+        }
 
         SettingsBody(
             ui                   = ui,
@@ -222,7 +231,8 @@ private fun SettingsBody(
         modifier = Modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
-            .padding(top = 96.dp, start = 24.dp, end = 24.dp, bottom = 24.dp),
+            .padding(top = 96.dp, start = 24.dp, end = 24.dp, bottom = 24.dp)
+            .testTag("settings_section"),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(24.dp)
     ) {

--- a/data/src/main/java/com/app/data/local/db/AppDb.kt
+++ b/data/src/main/java/com/app/data/local/db/AppDb.kt
@@ -29,7 +29,7 @@ import com.app.data.local.entities.UserEntity
         DailyMetricsEntity::class, OnboardingStatusEntity::class,
         DailyTipEntity::class
     ],
-    version = 2,
+    version = 4,
     exportSchema = true
 )
 @TypeConverters(

--- a/data/src/main/java/com/app/data/local/db/Migrations.kt
+++ b/data/src/main/java/com/app/data/local/db/Migrations.kt
@@ -18,3 +18,10 @@ val MIGRATION_2_3 = object : Migration(2, 3) {
         db.execSQL("""CREATE INDEX IF NOT EXISTS index_activities_timestamp ON activities(timestamp)""")
     }
 }
+
+/** v3 → v4 · nueva columna para tutorial */
+val MIGRATION_3_4 = object : Migration(3, 4) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE onboarding_status ADD COLUMN hasCompletedTutorial INTEGER NOT NULL DEFAULT 0")
+    }
+}

--- a/data/src/main/java/com/app/data/local/di/DatabaseModule.kt
+++ b/data/src/main/java/com/app/data/local/di/DatabaseModule.kt
@@ -6,6 +6,7 @@ import com.app.data.local.dao.*
 import com.app.data.local.db.AppDb
 import com.app.data.local.db.MIGRATION_1_2
 import com.app.data.local.db.MIGRATION_2_3
+import com.app.data.local.db.MIGRATION_3_4
 import com.app.data.local.security.SecurePassphraseProvider
 import dagger.Module
 import dagger.Provides
@@ -33,7 +34,7 @@ object DatabaseModule {
     ): AppDb =
         Room.databaseBuilder(ctx, AppDb::class.java, "tibi.db")
             .openHelperFactory(factory)
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3)       // 👈 sustituye fallbackToDestructive
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
             .build()
 
 

--- a/data/src/main/java/com/app/data/local/entities/OnboardingStatusEntity.kt
+++ b/data/src/main/java/com/app/data/local/entities/OnboardingStatusEntity.kt
@@ -12,6 +12,7 @@ import kotlinx.datetime.Instant
 @TypeConverters(DateTimeConverters::class)
 data class OnboardingStatusEntity(
     @PrimaryKey                      val uid: String,
+    val hasCompletedTutorial         : Boolean,
     val tutorialCompleted            : Boolean,
     val legalAccepted                : Boolean,
     val permissionsAsked             : Boolean,

--- a/data/src/main/java/com/app/data/mappers/OnboardingMapper.kt
+++ b/data/src/main/java/com/app/data/mappers/OnboardingMapper.kt
@@ -12,6 +12,7 @@ object OnboardingMappers {
 
     /** Entity → Domain */
     fun OnboardingStatusEntity.toDomain(): OnboardingStatus = OnboardingStatus(
+        hasCompletedTutorial = hasCompletedTutorial,
         tutorialCompleted = tutorialCompleted,
         legalAccepted     = legalAccepted,
         permissionsAsked  = permissionsAsked,
@@ -23,6 +24,7 @@ object OnboardingMappers {
     fun OnboardingStatus.toEntity(uid: String): OnboardingStatusEntity =
         OnboardingStatusEntity(
             uid               = uid,
+            hasCompletedTutorial = hasCompletedTutorial,
             tutorialCompleted = tutorialCompleted,
             legalAccepted     = legalAccepted,
             permissionsAsked  = permissionsAsked,

--- a/data/src/main/java/com/app/data/remote/firebase/OnboardingFirestoreService.kt
+++ b/data/src/main/java/com/app/data/remote/firebase/OnboardingFirestoreService.kt
@@ -30,6 +30,7 @@ class OnboardingFirestoreService @Inject constructor(
         if (!snap.exists()) return null
 
         return OnboardingStatus(
+            hasCompletedTutorial = snap.getBoolean("hasCompletedTutorial") ?: false,
             tutorialCompleted = snap.getBoolean("tutorialCompleted") ?: false,
             legalAccepted     = snap.getBoolean("legalAccepted") ?: false,
             permissionsAsked  = snap.getBoolean("permissionsAsked") ?: false,

--- a/data/src/main/java/com/app/data/repository/OnboardingRepositoryImpl.kt
+++ b/data/src/main/java/com/app/data/repository/OnboardingRepositoryImpl.kt
@@ -45,6 +45,7 @@ class OnboardingRepositoryImpl @Inject constructor(
             remote.push(
                 uid,
                 mapOf(
+                    "hasCompletedTutorial" to status.hasCompletedTutorial,
                     "tutorialCompleted" to status.tutorialCompleted,
                     "legalAccepted"     to status.legalAccepted,
                     "permissionsAsked"  to status.permissionsAsked,
@@ -53,6 +54,15 @@ class OnboardingRepositoryImpl @Inject constructor(
                 )
             )
         }
+
+    override suspend fun saveTutorialStatus(uid: String, completed: Boolean) {
+        val current = dao.find(uid)?.toDomain() ?: OnboardingStatus()
+        val updated = current.copy(
+            hasCompletedTutorial = completed,
+            meta = current.meta.copy(pendingSync = true)
+        )
+        save(uid, updated)
+    }
 
     override suspend fun syncNow(uid: String): Result<Unit> = withContext(io) {
         return@withContext runCatching {
@@ -74,6 +84,7 @@ class OnboardingRepositoryImpl @Inject constructor(
                 remote.push(
                     uid,
                     mapOf(
+                        "hasCompletedTutorial" to winner.hasCompletedTutorial,
                         "tutorialCompleted" to winner.tutorialCompleted,
                         "legalAccepted"     to winner.legalAccepted,
                         "permissionsAsked"  to winner.permissionsAsked,

--- a/domain/src/main/java/com/app/domain/entities/OnboardingStatus.kt
+++ b/domain/src/main/java/com/app/domain/entities/OnboardingStatus.kt
@@ -11,6 +11,8 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class OnboardingStatus(
+    /** Flag that marks if the interactive tutorial has been completed. */
+    val hasCompletedTutorial: Boolean = false,
     val tutorialCompleted : Boolean = false,
     val legalAccepted     : Boolean = false,
     val permissionsAsked  : Boolean = false,

--- a/domain/src/main/java/com/app/domain/repository/OnboardingRepository.kt
+++ b/domain/src/main/java/com/app/domain/repository/OnboardingRepository.kt
@@ -23,5 +23,6 @@ interface OnboardingRepository {
      * Debe disparar la sincronización remota en la capa de datos.
      */
     suspend fun save(uid: String, status: OnboardingStatus)
+    suspend fun saveTutorialStatus(uid: String, completed: Boolean)
     suspend fun syncNow(uid: String): Result<Unit>
 }

--- a/domain/src/main/java/com/app/domain/usecase/tutorial/SaveTutorialStatusUseCase.kt
+++ b/domain/src/main/java/com/app/domain/usecase/tutorial/SaveTutorialStatusUseCase.kt
@@ -1,0 +1,13 @@
+package com.app.domain.usecase.tutorial
+
+import com.app.domain.repository.OnboardingRepository
+import javax.inject.Inject
+
+/** Saves the completion state of the interactive tutorial. */
+class SaveTutorialStatusUseCase @Inject constructor(
+    private val repo: OnboardingRepository
+) {
+    suspend operator fun invoke(uid: String, completed: Boolean) {
+        repo.saveTutorialStatus(uid, completed)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ coil                  = "3.2.0"
 lottie                = "6.6.6"
 accompanist           = "0.37.3"
 spinwheel             = "1.1.1"
+tapTargetCompose      = "1.2.1"
 playServicesWearable  = "19.0.0"
 healthServices        = "1.0.0"
 wearCompose           = "1.4.1"
@@ -92,6 +93,7 @@ coil-network-okhttp      = { group = "io.coil-kt.coil3",           name = "coil-
 lottie-compose           = { group = "com.airbnb.android",         name = "lottie-compose",            version.ref = "lottie" }
 accompanist-permissions  = { group = "com.google.accompanist",     name = "accompanist-permissions",   version.ref = "accompanist" }
 spinwheel-compose        = { group = "com.github.commandiron",     name = "SpinWheelCompose",          version.ref = "spinwheel" }
+tap-target-compose       = { group = "com.pierfrancescosoffritti.taptargetcompose", name = "core", version.ref = "tapTargetCompose" }
 
 room-runtime             = { group = "androidx.room",             name = "room-runtime",              version.ref = "room" }
 room-ktx                 = { group = "androidx.room",             name = "room-ktx",                  version.ref = "room" }


### PR DESCRIPTION
## Summary
- add `hasCompletedTutorial` to onboarding status
- map new flag in Room and Firestore
- provide `SaveTutorialStatusUseCase`
- draft tutorial overlay and steps using Tap Target Compose
- hook overlay into `TibiBalanceRoot`
- add help buttons and anchors for tutorial steps
- bump DB version and add migration for tutorial flag

## Testing
- `./gradlew test --no-daemon` *(fails: Cannot find a Java installation matching 17)*

------
https://chatgpt.com/codex/tasks/task_e_6844f085ed988329a0bc7c500e901b73